### PR TITLE
Configure gpiozero pin factory via config.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,19 @@ pyproject.toml       # packaging and dependencies
 ## Install & run
 ```bash
 # On Raspberry Pi (with hardware deps):
+python -m venv .venv
+source .venv/bin/activate
 pip install -e ".[rpi]"
 python -m epaper
 
 # Dev/test (no GPIO hardware needed):
+python -m venv .venv
+source .venv/bin/activate
 pip install -e ".[dev]"
 pytest
+```
+
+If you get permission errors on SPI/GPIO devices, add your user to the required groups (then log out and back in):
+```bash
+sudo usermod -aG spi,gpio $USER
 ```

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,5 @@
 [bitcoin.price]
 service_endpoint = "https://blockchain.info/ticker"
+
+[gpiozero]
+pin_factory = "pigpio"

--- a/src/epaper/__main__.py
+++ b/src/epaper/__main__.py
@@ -1,6 +1,11 @@
 import logging
+import os
 import sys
 import traceback
+
+from epaper.config import config
+
+os.environ.setdefault("GPIOZERO_PIN_FACTORY", config().get("gpiozero", {}).get("pin_factory", "pigpio"))
 
 from epaper.display import PriceTicker
 from epaper.price.client import BitcoinPriceClient


### PR DESCRIPTION
## Summary
- Adds `[gpiozero]` section to `config.toml` to configure the pin factory
- Applies `GPIOZERO_PIN_FACTORY` env var at startup (before gpiozero is imported) to suppress `PinFactoryFallback` warnings
- Updates `CLAUDE.md` install instructions to use a venv and document GPIO group permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)