### PR TITLE
Harden exception handling in HTTP client, price client, and extractor

### DIFF
--- a/src/epaper/http_client.py
+++ b/src/epaper/http_client.py
@@ -42,7 +42,7 @@ class HttpClient:
         elif method == Method.DELETE:
             r = requests.delete(url, timeout=self.timeout)
 
-        if r.status_code not in (200, 201):
+        if not (200 <= r.status_code < 300):
             raise ConnectionError(f"\nCode: {r.status_code}\nResult: {r.text}\nData: {data}")
 
         return r.text

--- a/src/epaper/price/client.py
+++ b/src/epaper/price/client.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+import requests
+
 from epaper.config import config
 from epaper.http_client import HttpClient
 
@@ -12,6 +14,6 @@ class BitcoinPriceClient:
             result = HttpClient().get(endpoint)
             if result:
                 return json.loads(result)
-        except ConnectionError as e:
+        except (ConnectionError, requests.RequestException, json.JSONDecodeError) as e:
             logging.error(str(e))
         return None

--- a/src/epaper/price/extractor.py
+++ b/src/epaper/price/extractor.py
@@ -6,7 +6,12 @@ class PriceExtractor:
     def formatted_price_from_data(self, data: dict) -> str:
         if not data:
             return "N/A"
-        price = data[self.currency]["last"]
+        currency_data = data.get(self.currency)
+        if not currency_data:
+            return "N/A"
+        price = currency_data.get("last")
+        if price is None:
+            return "N/A"
         return self.format_price(price)
 
     def format_price(self, price: float) -> str:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -4,6 +4,29 @@ from unittest.mock import patch, MagicMock
 from epaper.http_client import HttpClient, DEFAULT_TIMEOUT
 
 
+class TestHttpClientStatusCodes(unittest.TestCase):
+    def _mock_response(self, status_code=200, text="{}"):
+        mock = MagicMock()
+        mock.status_code = status_code
+        mock.text = text
+        return mock
+
+    def test_2xx_codes_do_not_raise(self):
+        for code in (200, 201, 204, 206):
+            with patch("epaper.http_client.requests.get", return_value=self._mock_response(code)):
+                HttpClient().get("http://example.com")  # must not raise
+
+    def test_4xx_raises_connection_error(self):
+        with patch("epaper.http_client.requests.get", return_value=self._mock_response(404)):
+            with self.assertRaises(ConnectionError):
+                HttpClient().get("http://example.com")
+
+    def test_5xx_raises_connection_error(self):
+        with patch("epaper.http_client.requests.get", return_value=self._mock_response(500)):
+            with self.assertRaises(ConnectionError):
+                HttpClient().get("http://example.com")
+
+
 class TestHttpClientTimeout(unittest.TestCase):
     def _mock_response(self, status_code=200, text="{}"):
         mock = MagicMock()

--- a/tests/test_price_client.py
+++ b/tests/test_price_client.py
@@ -1,6 +1,11 @@
+import json
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+import requests
+
+from epaper.price.client import BitcoinPriceClient
 from epaper.price.extractor import PriceExtractor
 from epaper.price.mock import BitcoinPriceClientMock
 
@@ -27,6 +32,33 @@ class TestPriceExtractorIntegration(unittest.TestCase):
         extractor = PriceExtractor("USD", "$")
         self.assertEqual(extractor.formatted_price_from_data(None), "N/A")
         self.assertEqual(extractor.formatted_price_from_data({}), "N/A")
+
+
+class TestBitcoinPriceClientErrorHandling(unittest.TestCase):
+    def _client_with_mock_http(self, side_effect):
+        with patch("epaper.price.client.HttpClient") as MockHttp:
+            MockHttp.return_value.get.side_effect = side_effect
+            client = BitcoinPriceClient()
+            return client.retrieve_data()
+
+    def test_connection_error_returns_none(self):
+        result = self._client_with_mock_http(ConnectionError("connection refused"))
+        self.assertIsNone(result)
+
+    def test_requests_timeout_returns_none(self):
+        result = self._client_with_mock_http(requests.Timeout("timed out"))
+        self.assertIsNone(result)
+
+    def test_requests_exception_returns_none(self):
+        result = self._client_with_mock_http(requests.RequestException("network error"))
+        self.assertIsNone(result)
+
+    def test_malformed_json_returns_none(self):
+        with patch("epaper.price.client.HttpClient") as MockHttp:
+            MockHttp.return_value.get.return_value = "not valid json {"
+            client = BitcoinPriceClient()
+            result = client.retrieve_data()
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_price_extractor.py
+++ b/tests/test_price_extractor.py
@@ -22,6 +22,14 @@ class TestPriceExtractor(unittest.TestCase):
         self.assertEqual(self.extractor.format_price(123.45), "$123.000")
         self.assertEqual(self.extractor.format_price(0.99), "$0.000")
 
+    def test_unknown_currency_returns_na(self):
+        extractor = PriceExtractor("XYZ", "X")
+        self.assertEqual(extractor.formatted_price_from_data({"USD": {"last": 50000}}), "N/A")
+
+    def test_missing_last_key_returns_na(self):
+        extractor = PriceExtractor("USD", "$")
+        self.assertEqual(extractor.formatted_price_from_data({"USD": {"buy": 50000}}), "N/A")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes findings 7, 8, and 10 from the code review — all related to incomplete exception handling that could crash the display loop or silently produce wrong output.

- **Finding 7** (`http_client.py`): Accept any 2xx status code instead of only 200/201. Other valid codes like 204 or 206 previously raised `ConnectionError`.
- **Finding 8** (`price/client.py`): Broaden the `except` clause to also catch `requests.RequestException` (covers `Timeout`, network errors, etc.) and `json.JSONDecodeError`. Previously only `ConnectionError` was caught, so a timeout or malformed API response would propagate up and crash the display loop.
- **Finding 10** (`price/extractor.py`): Replace direct dict key access with `.get()` guards. An unknown currency or a response missing the `"last"` field now returns `"N/A"` instead of raising `KeyError`.

## Test plan

- [ ] `pytest` — all 26 tests pass
- [ ] `TestHttpClientStatusCodes` — verifies 200/201/204/206 succeed, 4xx/5xx raise `ConnectionError`
- [ ] `TestBitcoinPriceClientErrorHandling` — verifies `ConnectionError`, `Timeout`, `RequestException`, and malformed JSON all return `None`
- [ ] `TestPriceExtractor` — verifies unknown currency and missing `last` key both return `"N/A"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)