### PR TITLE
Require Python 3.13 and drop tomli fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Displays the current Bitcoin/USD price on a Waveshare 2.13" e-ink display (epd2i
 
 - Raspberry Pi (tested on Pi 5)
 - Waveshare 2.13" e-ink display (epd2in13 V2)
-- Python 3.9+
+- Python 3.13+
 
 ## Install & run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,10 @@ build-backend = "hatchling.build"
 [project]
 name = "epaper"
 version = "0.1.0"
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 dependencies = [
     "requests>=2.0.0",
     "Pillow>=10.0.0",
-    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/src/epaper/config.py
+++ b/src/epaper/config.py
@@ -1,7 +1,4 @@
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore[no-redef]
+import tomllib
 from pathlib import Path
 
 # Prefer config.toml next to the current working directory (production: the


### PR DESCRIPTION
## Summary

- Raise `requires-python` from `>=3.9` to `>=3.13` to match the actual target hardware (Raspberry Pi 5, Python 3.13.5 — and now also the dev machine).
- Remove the `tomli>=2.0.0; python_version < '3.11'` conditional dependency — it's dead weight since `tomllib` has been in the stdlib since 3.11.
- Simplify `config.py` to a plain `import tomllib`, dropping the try/except fallback.

## Test plan

- [ ] `pytest` — all 17 tests pass under Python 3.13.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)