### PR TITLE
Update and unpin outdated RPi optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ dependencies = [
 
 [project.optional-dependencies]
 rpi = [
-    "RPi.GPIO==0.7.1",
-    "spidev==3.4",
-    "pigpio==1.44",
+    "RPi.GPIO>=0.7.1",
+    "spidev>=3.8",
+    "pigpio>=1.78",
     "gpiozero>=1.6.2",
     "numpy>=2.0.0",
     "waveshare-epd @ git+https://github.com/waveshareteam/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python",


### PR DESCRIPTION
## Summary

- `spidev==3.4` → `spidev>=3.8` (was 4 minor versions behind)
- `pigpio==1.44` → `pigpio>=1.78` (was significantly behind)
- `RPi.GPIO==0.7.1` → `RPi.GPIO>=0.7.1` (already latest, but exact pins belong in a lockfile not pyproject.toml)
- `gpiozero` and `numpy` were already using `>=` — no change needed

## Test plan

- [ ] `pytest` — all 17 tests pass
- [ ] Install `.[rpi]` on the Pi and verify the service still starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)