### PR TITLE
Replace counter-based refresh timing with time.monotonic()

### DIFF
--- a/src/epaper/display.py
+++ b/src/epaper/display.py
@@ -72,10 +72,10 @@ class PriceTicker:
 
     def _display_price(self) -> None:
         font = ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
-        counter = 0
+        last_refresh = 0.0  # trigger immediate refresh on first iteration
 
         while self._running:
-            if counter % PRICE_REFRESH_INTERVAL == 0:
+            if time.monotonic() - last_refresh >= PRICE_REFRESH_INTERVAL:
                 self._epd.init(self._epd.FULL_UPDATE)
                 self._epd.Clear(0xFF)
 
@@ -93,8 +93,6 @@ class PriceTicker:
 
                 self._epd.display(self._epd.getbuffer(frame))
                 self._epd.sleep()
+                last_refresh = time.monotonic()
 
             time.sleep(1)
-            counter += 1
-            if counter >= PRICE_REFRESH_INTERVAL:
-                counter = 0

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 def _make_mock_epd2in13_module():
@@ -38,6 +38,61 @@ class TestPriceTickerStop(unittest.TestCase):
         self.assertTrue(self.ticker._running)
         self.ticker.stop()
         self.assertFalse(self.ticker._running)
+
+
+class TestPriceTickerRefreshTiming(unittest.TestCase):
+    def setUp(self):
+        fake_mod, self.mock_epd = _make_mock_epd2in13_module()
+        sys.modules.setdefault("epaper.lib.epdconfig", MagicMock())
+        sys.modules["epaper.lib.epd2in13_V2"] = fake_mod
+        sys.modules.pop("epaper.display", None)
+
+        from epaper.display import PriceTicker, PRICE_REFRESH_INTERVAL
+        self.PriceTicker = PriceTicker
+        self.PRICE_REFRESH_INTERVAL = PRICE_REFRESH_INTERVAL
+
+    def _run_one_iteration(self, monotonic_values, ticker):
+        """Pump _display_price for one iteration then stop the ticker."""
+        iter_values = iter(monotonic_values)
+        with patch("epaper.display.time.monotonic", side_effect=iter_values), \
+             patch("epaper.display.time.sleep", side_effect=lambda _: ticker.stop()), \
+             patch("epaper.display.ImageFont.truetype", return_value=MagicMock()), \
+             patch("epaper.display.Image.new", return_value=MagicMock()), \
+             patch("epaper.display.ImageDraw.Draw", return_value=MagicMock()):
+            ticker._display_price()
+
+    def test_first_iteration_always_refreshes(self):
+        """last_refresh starts at 0.0 so the first check always triggers."""
+        ticker = self.PriceTicker(price_client=MagicMock(), price_extractor=MagicMock())
+        # monotonic() returns a large value — well past the interval from 0.0
+        self._run_one_iteration([9999.0, 9999.0], ticker)
+        self.mock_epd.display.assert_called_once()
+
+    def test_no_refresh_within_interval(self):
+        """If less than PRICE_REFRESH_INTERVAL seconds have passed, skip the refresh."""
+        ticker = self.PriceTicker(price_client=MagicMock(), price_extractor=MagicMock())
+        # First iteration refreshes and records last_refresh = t1
+        # Second iteration checks at t1 + (interval - 1): should NOT refresh again
+        t1 = 9999.0
+        t2 = t1 + self.PRICE_REFRESH_INTERVAL - 1
+
+        call_count = 0
+
+        def stop_on_second_sleep(_):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                ticker.stop()
+
+        with patch("epaper.display.time.monotonic", side_effect=[t1, t1, t2]), \
+             patch("epaper.display.time.sleep", side_effect=stop_on_second_sleep), \
+             patch("epaper.display.ImageFont.truetype", return_value=MagicMock()), \
+             patch("epaper.display.Image.new", return_value=MagicMock()), \
+             patch("epaper.display.ImageDraw.Draw", return_value=MagicMock()):
+            ticker._display_price()
+
+        # display should have been called exactly once (the first refresh)
+        self.assertEqual(self.mock_epd.display.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The old loop incremented a counter once per `sleep(1)` and refreshed every 300 counts. Each `epd.display()`, `epd.init()`, and `epd.Clear()` call takes non-trivial time that wasn't accounted for, causing the effective refresh interval to grow longer and longer over hours of uptime.

`time.monotonic()` measures actual elapsed time between refreshes, so the interval stays accurate regardless of how long each display update takes. `last_refresh = 0.0` ensures the first iteration still fires immediately on startup.

## Test plan

- [ ] `pytest` — all 19 tests pass
- [ ] `test_first_iteration_always_refreshes` — verifies refresh fires on the first loop iteration
- [ ] `test_no_refresh_within_interval` — verifies no second refresh is triggered before the interval has elapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)