### PR TITLE
Center price text on the display

### DIFF
--- a/src/epaper/display.py
+++ b/src/epaper/display.py
@@ -89,7 +89,9 @@ class PriceTicker:
                 price = self.price_extractor.formatted_price_from_data(
                     self.price_client.retrieve_data()
                 )
-                draw.text((50, 33), price, font=font, fill=fg)
+                x = self.width // 2
+                y = self.height // 2
+                draw.text((x, y), price, font=font, fill=fg, anchor="mm")
 
                 self._epd.display(self._epd.getbuffer(frame))
                 self._epd.sleep()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, call
 
 
 def _make_mock_epd2in13_module():
@@ -38,6 +38,37 @@ class TestPriceTickerStop(unittest.TestCase):
         self.assertTrue(self.ticker._running)
         self.ticker.stop()
         self.assertFalse(self.ticker._running)
+
+
+class TestPriceTickerTextCentering(unittest.TestCase):
+    def setUp(self):
+        fake_mod, self.mock_epd = _make_mock_epd2in13_module()
+        sys.modules.setdefault("epaper.lib.epdconfig", MagicMock())
+        sys.modules["epaper.lib.epd2in13_V2"] = fake_mod
+        sys.modules.pop("epaper.display", None)
+
+        from epaper.display import PriceTicker
+        self.mock_draw = MagicMock()
+        self.ticker = PriceTicker(
+            price_client=MagicMock(),
+            price_extractor=MagicMock(formatted_price_from_data=MagicMock(return_value="$84.99k")),
+        )
+
+    def test_price_drawn_at_canvas_center_with_mm_anchor(self):
+        expected_x = self.ticker.width // 2   # 125
+        expected_y = self.ticker.height // 2  # 61
+
+        with patch("epaper.display.time.monotonic", return_value=9999.0), \
+             patch("epaper.display.time.sleep", side_effect=lambda _: self.ticker.stop()), \
+             patch("epaper.display.ImageFont.truetype", return_value=MagicMock()), \
+             patch("epaper.display.Image.new", return_value=MagicMock()), \
+             patch("epaper.display.ImageDraw.Draw", return_value=self.mock_draw):
+            self.ticker._display_price()
+
+        self.mock_draw.text.assert_called_once()
+        args, kwargs = self.mock_draw.text.call_args
+        self.assertEqual(args[0], (expected_x, expected_y))
+        self.assertEqual(kwargs.get("anchor"), "mm")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replace the hardcoded text position `(50, 33)` with the canvas center `(width//2, height//2)` and Pillow's `anchor="mm"` (middle-middle). Pillow aligns the midpoint of the text bounding box to those coordinates, so the price is always visually centered regardless of string length — `"$1.234M"` and `"N/A"` both land in the middle.

`anchor` was introduced in Pillow 8.0.0; our requirement is `>=10.0.0` so this is safe.

## Test plan

- [ ] `pytest` — all 18 tests pass
- [ ] `test_price_drawn_at_canvas_center_with_mm_anchor` — verifies `draw.text` is called with `(125, 61)` and `anchor="mm"`
- [ ] Visual check on the Pi for a few price strings of different lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)