### PR TITLE
Fix all remaining nice-to-have findings (12–18)

### DIFF
--- a/src/epaper/__main__.py
+++ b/src/epaper/__main__.py
@@ -13,7 +13,7 @@ from epaper.price.client import BitcoinPriceClient
 from epaper.price.extractor import PriceExtractor
 from epaper.utils.graceful_shutdown import GracefulShutdown
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 def main() -> None:
@@ -22,20 +22,16 @@ def main() -> None:
     ticker = PriceTicker(price_client, price_extractor)
     shutdown = GracefulShutdown()
 
-    def _on_signal(signum, frame):
-        shutdown._exit(signum, frame)
-        ticker.stop()
-
-    signal.signal(signal.SIGINT, _on_signal)
-    signal.signal(signal.SIGTERM, _on_signal)
-
     try:
         ticker.start()
+        while not shutdown.kill_now:
+            ticker.tick()
     except Exception as ex:
         logging.error(ex)
-        ticker.stop()
         traceback.print_exc(file=sys.stdout)
         sys.exit(1)
+    finally:
+        ticker.stop()
 
 
 if __name__ == "__main__":

--- a/src/epaper/display.py
+++ b/src/epaper/display.py
@@ -31,11 +31,15 @@ class PriceTicker:
     def __init__(self, price_client, price_extractor) -> None:
         self.price_client = price_client
         self.price_extractor = price_extractor
-        self._running = True
+        self._stopped = False
+        self._last_refresh = 0.0  # triggers refresh on first tick()
         self._epd = None
+        # The display is used in landscape orientation: physical width (250px)
+        # maps to EPD.height, physical height (122px) maps to EPD.width.
         self.width = 0
         self.height = 0
         self._init_display()
+        self._font = ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
 
     def _init_display(self) -> None:
         self._epd = epd2in13_V2.EPD()
@@ -45,20 +49,41 @@ class PriceTicker:
         self.height = self._epd.width   # 122 pixels
 
     def start(self) -> None:
-        try:
-            self._display_image()
-            time.sleep(3)
-            self._display_price()
-        except Exception as ex:
-            logging.error(ex)
-        finally:
-            self.stop()
+        """Display the intro image and pause before the price loop begins."""
+        self._display_image()
+        time.sleep(3)
+
+    def tick(self) -> None:
+        """Run one iteration of the price refresh loop. Call repeatedly from main."""
+        if time.monotonic() - self._last_refresh >= PRICE_REFRESH_INTERVAL:
+            self._epd.init(self._epd.FULL_UPDATE)
+            self._epd.Clear(0xFF)
+
+            bg = random.choice([BLACK, WHITE])
+            fg = WHITE if bg == BLACK else BLACK
+
+            frame = Image.new("1", (self.width, self.height))
+            draw = ImageDraw.Draw(frame)
+            draw.rectangle((0, 0, self.width, self.height), fill=bg)
+
+            price = self.price_extractor.formatted_price_from_data(
+                self.price_client.retrieve_data()
+            )
+            x = self.width // 2
+            y = self.height // 2
+            draw.text((x, y), price, font=self._font, fill=fg, anchor="mm")
+
+            self._epd.display(self._epd.getbuffer(frame))
+            self._epd.sleep()
+            self._last_refresh = time.monotonic()
+
+        time.sleep(1)
 
     def stop(self) -> None:
         logging.info("shutting down")
-        if not self._running:
+        if self._stopped:
             return
-        self._running = False
+        self._stopped = True
         self._epd.init(self._epd.FULL_UPDATE)
         self._epd.Clear(0xFF)
         self._epd.sleep()
@@ -69,32 +94,3 @@ class PriceTicker:
         frame = Image.new("1", (self.width, self.height))
         frame.paste(image, (padding_left, 0))
         self._epd.display(self._epd.getbuffer(frame))
-
-    def _display_price(self) -> None:
-        font = ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
-        last_refresh = 0.0  # trigger immediate refresh on first iteration
-
-        while self._running:
-            if time.monotonic() - last_refresh >= PRICE_REFRESH_INTERVAL:
-                self._epd.init(self._epd.FULL_UPDATE)
-                self._epd.Clear(0xFF)
-
-                bg = random.choice([BLACK, WHITE])
-                fg = WHITE if bg == BLACK else BLACK
-
-                frame = Image.new("1", (self.width, self.height))
-                draw = ImageDraw.Draw(frame)
-                draw.rectangle((0, 0, self.width, self.height), fill=bg)
-
-                price = self.price_extractor.formatted_price_from_data(
-                    self.price_client.retrieve_data()
-                )
-                x = self.width // 2
-                y = self.height // 2
-                draw.text((x, y), price, font=font, fill=fg, anchor="mm")
-
-                self._epd.display(self._epd.getbuffer(frame))
-                self._epd.sleep()
-                last_refresh = time.monotonic()
-
-            time.sleep(1)

--- a/src/epaper/http_client.py
+++ b/src/epaper/http_client.py
@@ -1,14 +1,6 @@
 import json
-from enum import Enum
 
 import requests
-
-
-class Method(Enum):
-    GET = 1
-    POST = 2
-    PUT = 3
-    DELETE = 4
 
 
 DEFAULT_TIMEOUT = 10  # seconds
@@ -19,30 +11,20 @@ class HttpClient:
         self.timeout = timeout
 
     def get(self, url: str) -> str:
-        return self._perform(Method.GET, url)
+        return self._check(requests.get(url, timeout=self.timeout))
 
     def post(self, url: str, json_data=None) -> str:
-        return self._perform(Method.POST, url, json_data)
+        data = json.dumps(json_data) if json_data else None
+        return self._check(requests.post(url, data=data, timeout=self.timeout))
 
     def put(self, url: str, json_data=None) -> str:
-        return self._perform(Method.PUT, url, json_data)
+        data = json.dumps(json_data) if json_data else None
+        return self._check(requests.put(url, data=data, timeout=self.timeout))
 
     def delete(self, url: str) -> str:
-        return self._perform(Method.DELETE, url)
+        return self._check(requests.delete(url, timeout=self.timeout))
 
-    def _perform(self, method: Method, url: str, json_data=None) -> str:
-        data = json.dumps(json_data) if json_data else None
-
-        if method == Method.GET:
-            r = requests.get(url, timeout=self.timeout)
-        elif method == Method.POST:
-            r = requests.post(url, data=data, timeout=self.timeout)
-        elif method == Method.PUT:
-            r = requests.put(url, data=data, timeout=self.timeout)
-        elif method == Method.DELETE:
-            r = requests.delete(url, timeout=self.timeout)
-
+    def _check(self, r) -> str:
         if not (200 <= r.status_code < 300):
-            raise ConnectionError(f"\nCode: {r.status_code}\nResult: {r.text}\nData: {data}")
-
+            raise ConnectionError(f"\nCode: {r.status_code}\nResult: {r.text}")
         return r.text

--- a/src/epaper/price/extractor.py
+++ b/src/epaper/price/extractor.py
@@ -1,3 +1,6 @@
+import math
+
+
 class PriceExtractor:
     def __init__(self, currency: str, symbol: str) -> None:
         self.currency = currency
@@ -29,4 +32,4 @@ class PriceExtractor:
             return f"{self.symbol}{truncated:.3f}"
 
     def price_without_cents(self, price: float) -> float:
-        return float(str(price).split(".", 1)[0])
+        return float(math.floor(price))

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 
 def _make_mock_epd2in13_module():
@@ -15,55 +15,86 @@ def _make_mock_epd2in13_module():
     return mod, mock_epd_instance
 
 
+def _make_ticker():
+    fake_mod, mock_epd = _make_mock_epd2in13_module()
+    sys.modules.setdefault("epaper.lib.epdconfig", MagicMock())
+    sys.modules["epaper.lib.epd2in13_V2"] = fake_mod
+    sys.modules.pop("epaper.display", None)
+
+    with patch("epaper.display.ImageFont.truetype", return_value=MagicMock()):
+        from epaper.display import PriceTicker
+        ticker = PriceTicker(price_client=MagicMock(), price_extractor=MagicMock())
+
+    return ticker, mock_epd
+
+
 class TestPriceTickerStop(unittest.TestCase):
     def setUp(self):
-        # Stub out the driver modules before display.py is imported
-        fake_mod, self.mock_epd = _make_mock_epd2in13_module()
-        sys.modules.setdefault("epaper.lib.epdconfig", MagicMock())
-        sys.modules["epaper.lib.epd2in13_V2"] = fake_mod
-
-        # Remove cached display module so our stubs take effect
-        sys.modules.pop("epaper.display", None)
-
-        from epaper.display import PriceTicker
-        self.ticker = PriceTicker(price_client=MagicMock(), price_extractor=MagicMock())
+        self.ticker, self.mock_epd = _make_ticker()
 
     def test_stop_only_shuts_down_hardware_once(self):
         self.ticker.stop()
         self.ticker.stop()  # second call must be a no-op
-
         self.assertEqual(self.mock_epd.sleep.call_count, 1)
 
-    def test_stop_sets_running_false(self):
-        self.assertTrue(self.ticker._running)
+    def test_stop_sets_stopped_true(self):
+        self.assertFalse(self.ticker._stopped)
         self.ticker.stop()
-        self.assertFalse(self.ticker._running)
+        self.assertTrue(self.ticker._stopped)
 
 
 class TestPriceTickerRefreshTiming(unittest.TestCase):
     def setUp(self):
-        fake_mod, self.mock_epd = _make_mock_epd2in13_module()
-        sys.modules.setdefault("epaper.lib.epdconfig", MagicMock())
-        sys.modules["epaper.lib.epd2in13_V2"] = fake_mod
-        sys.modules.pop("epaper.display", None)
+        self.ticker, self.mock_epd = _make_ticker()
 
-        from epaper.display import PriceTicker
+    def _run_tick(self, monotonic_values):
+        with patch("epaper.display.time.monotonic", side_effect=monotonic_values), \
+             patch("epaper.display.time.sleep"), \
+             patch("epaper.display.Image.new", return_value=MagicMock()), \
+             patch("epaper.display.ImageDraw.Draw", return_value=MagicMock()):
+            self.ticker.tick()
+
+    def test_first_tick_always_refreshes(self):
+        """_last_refresh starts at 0.0 so the first tick always triggers a refresh."""
+        self._run_tick([9999.0, 9999.0])
+        self.mock_epd.display.assert_called_once()
+
+    def test_no_refresh_within_interval(self):
+        """A second tick within the interval must not trigger another refresh."""
+        from epaper.display import PRICE_REFRESH_INTERVAL
+        t1 = 9999.0
+        self._run_tick([t1, t1])  # first tick: refreshes, sets _last_refresh = t1
+
+        t2 = t1 + PRICE_REFRESH_INTERVAL - 1
+        self._run_tick([t2])      # second tick: too early, no refresh
+        self.assertEqual(self.mock_epd.display.call_count, 1)
+
+    def test_refresh_after_interval_elapsed(self):
+        """A tick after the full interval must trigger a refresh."""
+        from epaper.display import PRICE_REFRESH_INTERVAL
+        t1 = 9999.0
+        self._run_tick([t1, t1])  # first tick refreshes
+
+        t2 = t1 + PRICE_REFRESH_INTERVAL
+        self._run_tick([t2, t2])  # second tick: interval elapsed, refreshes again
+        self.assertEqual(self.mock_epd.display.call_count, 2)
+
+
+class TestPriceTickerTextCentering(unittest.TestCase):
+    def setUp(self):
+        self.ticker, _ = _make_ticker()
         self.mock_draw = MagicMock()
-        self.ticker = PriceTicker(
-            price_client=MagicMock(),
-            price_extractor=MagicMock(formatted_price_from_data=MagicMock(return_value="$84.99k")),
-        )
+        self.ticker.price_extractor.formatted_price_from_data.return_value = "$84.99k"
 
     def test_price_drawn_at_canvas_center_with_mm_anchor(self):
         expected_x = self.ticker.width // 2   # 125
         expected_y = self.ticker.height // 2  # 61
 
         with patch("epaper.display.time.monotonic", return_value=9999.0), \
-             patch("epaper.display.time.sleep", side_effect=lambda _: self.ticker.stop()), \
-             patch("epaper.display.ImageFont.truetype", return_value=MagicMock()), \
+             patch("epaper.display.time.sleep"), \
              patch("epaper.display.Image.new", return_value=MagicMock()), \
              patch("epaper.display.ImageDraw.Draw", return_value=self.mock_draw):
-            self.ticker._display_price()
+            self.ticker.tick()
 
         self.mock_draw.text.assert_called_once()
         args, kwargs = self.mock_draw.text.call_args

--- a/tests/test_price_extractor.py
+++ b/tests/test_price_extractor.py
@@ -5,7 +5,7 @@ from epaper.price.extractor import PriceExtractor
 
 class TestPriceExtractor(unittest.TestCase):
     def setUp(self):
-        self.extractor = PriceExtractor(currency="usd", symbol="$")
+        self.extractor = PriceExtractor(currency="USD", symbol="$")
 
     def test_format_price_in_millions(self):
         self.assertEqual(self.extractor.format_price(1234567), "$1.234M")


### PR DESCRIPTION
## Summary

Fixes findings 12–18 from the code review. 15, 16, and 17 were resolved as part of the finding 12 refactor.

### Finding 12 — Use `GracefulShutdown.kill_now` to drive the main loop
The `kill_now` flag was set but never read. Refactored `PriceTicker` to expose `tick()` (one refresh iteration) and moved the loop to `main()`, where `while not shutdown.kill_now` now drives termination. This removes the manual signal handler override and makes control flow visible at the top level. Font loading moved to `__init__` (once, not per loop entry).

### Finding 13 — Remove `Method` enum from `HttpClient`
The enum was an internal implementation detail of `_perform()` with no external use. Replaced with per-method `requests` calls and a shared `_check()` helper.

### Finding 14 — Replace string splitting with `math.floor`
`float(str(price).split('.')[0])` is fragile (breaks for `NaN`, `inf`, scientific notation). `math.floor()` is idiomatic.

### Finding 15 — `import signal` at top of file ✓ already fixed in PR #16

### Finding 16 — Change `DEBUG` logging to `INFO` ✓ done as part of finding 12

### Finding 17 — Explain width/height landscape swap ✓ done as part of finding 12

### Finding 18 — Fix test currency to uppercase `"USD"`
The unit test used `"usd"` while production uses `"USD"`, creating an inconsistency that could mask future bugs.

## Test plan

- [ ] `pytest` — all 30 tests pass
- [ ] 6 display tests cover `tick()`, `stop()` idempotency, timing, and text centering

🤖 Generated with [Claude Code](https://claude.com/claude-code)