### PR TITLE
Add retry logic for failed price fetches

### DIFF
--- a/src/epaper/price/client.py
+++ b/src/epaper/price/client.py
@@ -1,19 +1,27 @@
 import json
 import logging
+import time
 
 import requests
 
 from epaper.config import config
 from epaper.http_client import HttpClient
 
+MAX_RETRIES = 3
+RETRY_DELAY = 5  # seconds between attempts
+
 
 class BitcoinPriceClient:
     def retrieve_data(self):
         endpoint = config()["bitcoin"]["price"]["service_endpoint"]
-        try:
-            result = HttpClient().get(endpoint)
-            if result:
-                return json.loads(result)
-        except (ConnectionError, requests.RequestException, json.JSONDecodeError) as e:
-            logging.error(str(e))
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                result = HttpClient().get(endpoint)
+                if result:
+                    return json.loads(result)
+            except (ConnectionError, requests.RequestException, json.JSONDecodeError) as e:
+                logging.warning("Price fetch attempt %d/%d failed: %s", attempt, MAX_RETRIES, e)
+                if attempt < MAX_RETRIES:
+                    time.sleep(RETRY_DELAY)
+        logging.error("All %d price fetch attempts failed", MAX_RETRIES)
         return None

--- a/tests/test_price_client.py
+++ b/tests/test_price_client.py
@@ -1,11 +1,11 @@
 import json
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, call
 
 import requests
 
-from epaper.price.client import BitcoinPriceClient
+from epaper.price.client import BitcoinPriceClient, MAX_RETRIES, RETRY_DELAY
 from epaper.price.extractor import PriceExtractor
 from epaper.price.mock import BitcoinPriceClientMock
 
@@ -35,30 +35,74 @@ class TestPriceExtractorIntegration(unittest.TestCase):
 
 
 class TestBitcoinPriceClientErrorHandling(unittest.TestCase):
-    def _client_with_mock_http(self, side_effect):
-        with patch("epaper.price.client.HttpClient") as MockHttp:
+    def _run_with_error(self, side_effect):
+        with patch("epaper.price.client.HttpClient") as MockHttp, \
+             patch("epaper.price.client.time.sleep"):
             MockHttp.return_value.get.side_effect = side_effect
-            client = BitcoinPriceClient()
-            return client.retrieve_data()
+            return BitcoinPriceClient().retrieve_data()
 
     def test_connection_error_returns_none(self):
-        result = self._client_with_mock_http(ConnectionError("connection refused"))
-        self.assertIsNone(result)
+        self.assertIsNone(self._run_with_error(ConnectionError("connection refused")))
 
     def test_requests_timeout_returns_none(self):
-        result = self._client_with_mock_http(requests.Timeout("timed out"))
-        self.assertIsNone(result)
+        self.assertIsNone(self._run_with_error(requests.Timeout("timed out")))
 
     def test_requests_exception_returns_none(self):
-        result = self._client_with_mock_http(requests.RequestException("network error"))
-        self.assertIsNone(result)
+        self.assertIsNone(self._run_with_error(requests.RequestException("network error")))
 
     def test_malformed_json_returns_none(self):
-        with patch("epaper.price.client.HttpClient") as MockHttp:
+        with patch("epaper.price.client.HttpClient") as MockHttp, \
+             patch("epaper.price.client.time.sleep"):
             MockHttp.return_value.get.return_value = "not valid json {"
-            client = BitcoinPriceClient()
-            result = client.retrieve_data()
+            self.assertIsNone(BitcoinPriceClient().retrieve_data())
+
+
+class TestBitcoinPriceClientRetry(unittest.TestCase):
+    def test_succeeds_on_first_attempt_without_retrying(self):
+        good_response = json.dumps({"USD": {"last": 50000}})
+        with patch("epaper.price.client.HttpClient") as MockHttp, \
+             patch("epaper.price.client.time.sleep") as mock_sleep:
+            MockHttp.return_value.get.return_value = good_response
+            result = BitcoinPriceClient().retrieve_data()
+
+        self.assertIsNotNone(result)
+        mock_sleep.assert_not_called()
+
+    def test_retries_on_failure_and_returns_data_on_success(self):
+        good_response = json.dumps({"USD": {"last": 50000}})
+        with patch("epaper.price.client.HttpClient") as MockHttp, \
+             patch("epaper.price.client.time.sleep") as mock_sleep:
+            # Fail twice, succeed on third attempt
+            MockHttp.return_value.get.side_effect = [
+                ConnectionError("fail"),
+                ConnectionError("fail"),
+                good_response,
+            ]
+            result = BitcoinPriceClient().retrieve_data()
+
+        self.assertIsNotNone(result)
+        self.assertEqual(mock_sleep.call_count, 2)
+        mock_sleep.assert_called_with(RETRY_DELAY)
+
+    def test_exhausts_all_retries_and_returns_none(self):
+        with patch("epaper.price.client.HttpClient") as MockHttp, \
+             patch("epaper.price.client.time.sleep") as mock_sleep:
+            MockHttp.return_value.get.side_effect = ConnectionError("always fails")
+            result = BitcoinPriceClient().retrieve_data()
+
         self.assertIsNone(result)
+        self.assertEqual(MockHttp.return_value.get.call_count, MAX_RETRIES)
+        self.assertEqual(mock_sleep.call_count, MAX_RETRIES - 1)  # no sleep after last attempt
+
+    def test_no_sleep_after_last_failed_attempt(self):
+        with patch("epaper.price.client.HttpClient") as MockHttp, \
+             patch("epaper.price.client.time.sleep") as mock_sleep:
+            MockHttp.return_value.get.side_effect = ConnectionError("fail")
+            BitcoinPriceClient().retrieve_data()
+
+        # sleep called between attempts, never after the last one
+        sleep_calls = mock_sleep.call_count
+        self.assertEqual(sleep_calls, MAX_RETRIES - 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A single network hiccup previously caused `"N/A"` to show on the display for the full 5-minute interval. `retrieve_data()` now retries up to **3 times** with a **5-second delay** between attempts before returning `None`. No sleep is added after the final attempt.

Constants `MAX_RETRIES` and `RETRY_DELAY` are module-level in `client.py` and used directly by the tests.

## Test plan

- [ ] `pytest` — all 34 tests pass
- [ ] `test_succeeds_on_first_attempt_without_retrying` — no sleep on clean success
- [ ] `test_retries_on_failure_and_returns_data_on_success` — recovers after 2 failures
- [ ] `test_exhausts_all_retries_and_returns_none` — all 3 attempts made, returns `None`
- [ ] `test_no_sleep_after_last_failed_attempt` — exactly `MAX_RETRIES - 1` sleeps

🤖 Generated with [Claude Code](https://claude.com/claude-code)