### PR TITLE
Add systemd watchdog integration

### DIFF
--- a/src/epaper/__main__.py
+++ b/src/epaper/__main__.py
@@ -12,6 +12,7 @@ from epaper.display import PriceTicker
 from epaper.price.client import BitcoinPriceClient
 from epaper.price.extractor import PriceExtractor
 from epaper.utils.graceful_shutdown import GracefulShutdown
+from epaper.utils.watchdog import sd_notify
 
 logging.basicConfig(level=logging.INFO)
 
@@ -24,8 +25,10 @@ def main() -> None:
 
     try:
         ticker.start()
+        sd_notify("READY=1")
         while not shutdown.kill_now:
             ticker.tick()
+            sd_notify("WATCHDOG=1")
     except Exception as ex:
         logging.error(ex)
         traceback.print_exc(file=sys.stdout)

--- a/src/epaper/utils/watchdog.py
+++ b/src/epaper/utils/watchdog.py
@@ -1,0 +1,17 @@
+import os
+import socket
+
+
+def sd_notify(message: str) -> None:
+    """Send a notification to systemd via the sd_notify protocol.
+
+    Does nothing when NOTIFY_SOCKET is not set (i.e. not running under systemd).
+    Supports both filesystem paths and abstract Unix sockets (prefixed with '@').
+    """
+    notify_socket = os.environ.get("NOTIFY_SOCKET")
+    if not notify_socket:
+        return
+    # Abstract sockets use '\0' as the first byte; systemd signals this with '@'
+    addr = "\0" + notify_socket[1:] if notify_socket.startswith("@") else notify_socket
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+        sock.sendto(message.encode(), addr)

--- a/systemd/epaper.service
+++ b/systemd/epaper.service
@@ -9,6 +9,9 @@ WorkingDirectory=/home/pi/epaper
 ExecStart=/home/pi/epaper/.venv/bin/python -m epaper
 Restart=on-failure
 RestartSec=10
+Type=notify
+WatchdogSec=60
+NotifyAccess=main
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,52 @@
+import os
+import socket
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from epaper.utils.watchdog import sd_notify
+
+
+class TestSdNotify(unittest.TestCase):
+    def test_does_nothing_when_notify_socket_not_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("NOTIFY_SOCKET", None)
+            # Must not raise
+            sd_notify("WATCHDOG=1")
+
+    def test_sends_message_to_filesystem_socket(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sock_path = os.path.join(tmpdir, "notify.sock")
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            server.bind(sock_path)
+            server.settimeout(1)
+
+            with patch.dict(os.environ, {"NOTIFY_SOCKET": sock_path}):
+                sd_notify("READY=1")
+
+            data = server.recv(64)
+            server.close()
+            self.assertEqual(data, b"READY=1")
+
+    def test_sends_watchdog_ping(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sock_path = os.path.join(tmpdir, "notify.sock")
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            server.bind(sock_path)
+            server.settimeout(1)
+
+            with patch.dict(os.environ, {"NOTIFY_SOCKET": sock_path}):
+                sd_notify("WATCHDOG=1")
+
+            data = server.recv(64)
+            server.close()
+            self.assertEqual(data, b"WATCHDOG=1")
+
+    def test_silently_ignores_missing_socket_env(self):
+        env_without_socket = {k: v for k, v in os.environ.items() if k != "NOTIFY_SOCKET"}
+        with patch.dict(os.environ, env_without_socket, clear=True):
+            sd_notify("READY=1")  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`Restart=on-failure` only catches crashes. If the display loop or SPI communication hangs, the process stays alive and systemd never restarts it.

This PR adds watchdog support using the `sd_notify` protocol directly over the `NOTIFY_SOCKET` Unix socket — no extra package required.

**Changes:**
- `utils/watchdog.py` — stdlib-only `sd_notify()` helper; silently does nothing when `NOTIFY_SOCKET` is not set (i.e. outside of systemd)
- `__main__.py` — sends `READY=1` after startup, `WATCHDOG=1` after every `tick()` call
- `epaper.service` — adds `Type=notify`, `WatchdogSec=60`, `NotifyAccess=main`

If the tick loop stops pinging within 60 seconds, systemd kills and restarts the service automatically.

## Deploying on the Pi

After merging, copy the updated service file and reload systemd:
```bash
sudo cp systemd/epaper.service /etc/systemd/system/epaper.service
sudo systemctl daemon-reload
sudo systemctl restart epaper
```

## Test plan

- [ ] `pytest` — all 34 tests pass
- [ ] `test_sends_message_to_filesystem_socket` — verifies `READY=1` reaches the socket
- [ ] `test_sends_watchdog_ping` — verifies `WATCHDOG=1` reaches the socket
- [ ] `test_does_nothing_when_notify_socket_not_set` — no crash outside systemd

🤖 Generated with [Claude Code](https://claude.com/claude-code)