### PR TITLE
Replace config singleton with functools.lru_cache

### DIFF
--- a/src/epaper/config.py
+++ b/src/epaper/config.py
@@ -1,4 +1,5 @@
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 
 # Prefer config.toml next to the current working directory (production: the
@@ -7,12 +8,8 @@ _CWD_CONFIG = Path.cwd() / "config.toml"
 _REPO_CONFIG = Path(__file__).parents[2] / "config.toml"
 _CONFIG_PATH = _CWD_CONFIG if _CWD_CONFIG.exists() else _REPO_CONFIG
 
-_config = None
 
-
+@lru_cache(maxsize=None)
 def config() -> dict:
-    global _config
-    if _config is None:
-        with open(_CONFIG_PATH, "rb") as f:
-            _config = tomllib.load(f)
-    return _config
+    with open(_CONFIG_PATH, "rb") as f:
+        return tomllib.load(f)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,6 @@ class TestConfigLoader(unittest.TestCase):
     def _fresh_config_module(self):
         sys.modules.pop("epaper.config", None)
         import epaper.config
-        epaper.config._config = None
         return epaper.config
 
     def test_loads_from_cwd_when_config_toml_present(self):
@@ -30,7 +29,6 @@ class TestConfigLoader(unittest.TestCase):
 
     def test_falls_back_to_repo_config_when_no_cwd_config(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            # tmpdir has no config.toml
             with patch("pathlib.Path.cwd", return_value=Path(tmpdir)):
                 mod = self._fresh_config_module()
 
@@ -39,6 +37,7 @@ class TestConfigLoader(unittest.TestCase):
     def test_config_loads_from_repo_config(self):
         mod = self._fresh_config_module()
         mod._CONFIG_PATH = _REAL_CONFIG
+        mod.config.cache_clear()
         result = mod.config()
         self.assertIsInstance(result, dict)
         self.assertIn("bitcoin", result)


### PR DESCRIPTION
## Summary

Replace the mutable `_config` global and manual `None` check with `@lru_cache(maxsize=None)` on `config()`. Same single-load behaviour, thread-safe, and idiomatic Python — in three fewer lines.

```python
# before
_config = None

def config() -> dict:
    global _config
    if _config is None:
        with open(_CONFIG_PATH, "rb") as f:
            _config = tomllib.load(f)
    return _config

# after
@lru_cache(maxsize=None)
def config() -> dict:
    with open(_CONFIG_PATH, "rb") as f:
        return tomllib.load(f)
```

Tests updated to use `config.cache_clear()` instead of `_config = None`.

## Test plan

- [ ] `pytest` — all 30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)