### PR TITLE
Separate display hardware abstraction from ticker orchestration

### DIFF
--- a/src/epaper/__main__.py
+++ b/src/epaper/__main__.py
@@ -8,9 +8,10 @@ from epaper.config import config
 
 os.environ.setdefault("GPIOZERO_PIN_FACTORY", config().get("gpiozero", {}).get("pin_factory", "pigpio"))
 
-from epaper.display import PriceTicker
+from epaper.display import Display
 from epaper.price.client import BitcoinPriceClient
 from epaper.price.extractor import PriceExtractor
+from epaper.ticker import PriceTicker
 from epaper.utils.graceful_shutdown import GracefulShutdown
 from epaper.utils.watchdog import sd_notify
 
@@ -18,9 +19,10 @@ logging.basicConfig(level=logging.INFO)
 
 
 def main() -> None:
+    display = Display()
     price_client = BitcoinPriceClient()
     price_extractor = PriceExtractor("USD", "$")
-    ticker = PriceTicker(price_client, price_extractor)
+    ticker = PriceTicker(display, price_client, price_extractor)
     shutdown = GracefulShutdown()
 
     try:

--- a/src/epaper/display.py
+++ b/src/epaper/display.py
@@ -1,14 +1,10 @@
-import logging
-import random
 import sys
-import time
 from pathlib import Path
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image
 
 _PKG_DIR = Path(__file__).parent
 _LIB_DIR = _PKG_DIR / "lib"
-_MEDIA_DIR = _PKG_DIR / "media"
 
 if _LIB_DIR.exists():
     sys.path.insert(0, str(_LIB_DIR))
@@ -18,79 +14,30 @@ try:
 except ModuleNotFoundError:
     from epaper.lib import epd2in13_V2
 
-FONT_FILE = _MEDIA_DIR / "UbuntuBoldItalic-Rg86.ttf"
-IMAGE_FILE = _MEDIA_DIR / "bitcoin122x122_b.bmp"
-FONT_SIZE = 48  # 48 points = 64 pixels
-PRICE_REFRESH_INTERVAL = 300  # seconds
 
-WHITE = 255
-BLACK = 0
+class Display:
+    """Hardware abstraction over the Waveshare epd2in13_V2 e-paper display.
 
+    Handles initialisation, image rendering, and power management.
+    The display is used in landscape orientation: physical width (250px)
+    maps to EPD.height, physical height (122px) maps to EPD.width.
+    """
 
-class PriceTicker:
-    def __init__(self, price_client, price_extractor) -> None:
-        self.price_client = price_client
-        self.price_extractor = price_extractor
-        self._stopped = False
-        self._last_refresh = 0.0  # triggers refresh on first tick()
-        self._epd = None
-        # The display is used in landscape orientation: physical width (250px)
-        # maps to EPD.height, physical height (122px) maps to EPD.width.
-        self.width = 0
-        self.height = 0
-        self._init_display()
-        self._font = ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
-
-    def _init_display(self) -> None:
+    def __init__(self) -> None:
         self._epd = epd2in13_V2.EPD()
         self._epd.init(self._epd.FULL_UPDATE)
         self._epd.Clear(0xFF)
         self.width = self._epd.height   # 250 pixels
         self.height = self._epd.width   # 122 pixels
 
-    def start(self) -> None:
-        """Display the intro image and pause before the price loop begins."""
-        self._display_image()
-        time.sleep(3)
-
-    def tick(self) -> None:
-        """Run one iteration of the price refresh loop. Call repeatedly from main."""
-        if time.monotonic() - self._last_refresh >= PRICE_REFRESH_INTERVAL:
-            self._epd.init(self._epd.FULL_UPDATE)
-            self._epd.Clear(0xFF)
-
-            bg = random.choice([BLACK, WHITE])
-            fg = WHITE if bg == BLACK else BLACK
-
-            frame = Image.new("1", (self.width, self.height))
-            draw = ImageDraw.Draw(frame)
-            draw.rectangle((0, 0, self.width, self.height), fill=bg)
-
-            price = self.price_extractor.formatted_price_from_data(
-                self.price_client.retrieve_data()
-            )
-            x = self.width // 2
-            y = self.height // 2
-            draw.text((x, y), price, font=self._font, fill=fg, anchor="mm")
-
-            self._epd.display(self._epd.getbuffer(frame))
-            self._epd.sleep()
-            self._last_refresh = time.monotonic()
-
-        time.sleep(1)
-
-    def stop(self) -> None:
-        logging.info("shutting down")
-        if self._stopped:
-            return
-        self._stopped = True
+    def init(self) -> None:
         self._epd.init(self._epd.FULL_UPDATE)
-        self._epd.Clear(0xFF)
-        self._epd.sleep()
 
-    def _display_image(self) -> None:
-        image = Image.open(IMAGE_FILE)
-        padding_left = (self.width - image.size[0]) // 2
-        frame = Image.new("1", (self.width, self.height))
-        frame.paste(image, (padding_left, 0))
-        self._epd.display(self._epd.getbuffer(frame))
+    def clear(self) -> None:
+        self._epd.Clear(0xFF)
+
+    def show(self, image: Image.Image) -> None:
+        self._epd.display(self._epd.getbuffer(image))
+
+    def sleep(self) -> None:
+        self._epd.sleep()

--- a/src/epaper/ticker.py
+++ b/src/epaper/ticker.py
@@ -1,0 +1,78 @@
+import logging
+import random
+import time
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from epaper.display import Display
+
+_MEDIA_DIR = Path(__file__).parent / "media"
+
+FONT_FILE = _MEDIA_DIR / "UbuntuBoldItalic-Rg86.ttf"
+IMAGE_FILE = _MEDIA_DIR / "bitcoin122x122_b.bmp"
+FONT_SIZE = 48  # 48 points = 64 pixels
+PRICE_REFRESH_INTERVAL = 300  # seconds
+
+WHITE = 255
+BLACK = 0
+
+
+class PriceTicker:
+    """Orchestrates price refresh cycles on the e-paper display.
+
+    Handles timing, price fetching, frame rendering, and delegating
+    all hardware operations to the Display instance.
+    """
+
+    def __init__(self, display: Display, price_client, price_extractor) -> None:
+        self.display = display
+        self.price_client = price_client
+        self.price_extractor = price_extractor
+        self._stopped = False
+        self._last_refresh = 0.0  # triggers refresh on first tick()
+        self._font = ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
+
+    def start(self) -> None:
+        """Display the intro image and pause before the price loop begins."""
+        image = Image.open(IMAGE_FILE)
+        padding_left = (self.display.width - image.size[0]) // 2
+        frame = Image.new("1", (self.display.width, self.display.height))
+        frame.paste(image, (padding_left, 0))
+        self.display.show(frame)
+        time.sleep(3)
+
+    def tick(self) -> None:
+        """Run one iteration of the price refresh loop. Call repeatedly from main."""
+        if time.monotonic() - self._last_refresh >= PRICE_REFRESH_INTERVAL:
+            self.display.init()
+            self.display.clear()
+
+            bg = random.choice([BLACK, WHITE])
+            fg = WHITE if bg == BLACK else BLACK
+
+            frame = Image.new("1", (self.display.width, self.display.height))
+            draw = ImageDraw.Draw(frame)
+            draw.rectangle((0, 0, self.display.width, self.display.height), fill=bg)
+
+            price = self.price_extractor.formatted_price_from_data(
+                self.price_client.retrieve_data()
+            )
+            x = self.display.width // 2
+            y = self.display.height // 2
+            draw.text((x, y), price, font=self._font, fill=fg, anchor="mm")
+
+            self.display.show(frame)
+            self.display.sleep()
+            self._last_refresh = time.monotonic()
+
+        time.sleep(1)
+
+    def stop(self) -> None:
+        logging.info("shutting down")
+        if self._stopped:
+            return
+        self._stopped = True
+        self.display.init()
+        self.display.clear()
+        self.display.sleep()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,105 +1,57 @@
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
-def _make_mock_epd2in13_module():
-    """Return a fake epd2in13_V2 module so the ARM .so is never loaded."""
-    mod = types.ModuleType("epaper.lib.epd2in13_V2")
+def _stub_epd_module():
+    """Stub out the ARM driver so tests run on any platform."""
     mock_epd_instance = MagicMock()
     mock_epd_instance.FULL_UPDATE = "FULL_UPDATE"
     mock_epd_instance.height = 250
     mock_epd_instance.width = 122
+
+    mod = types.ModuleType("epaper.lib.epd2in13_V2")
     mod.EPD = MagicMock(return_value=mock_epd_instance)
-    return mod, mock_epd_instance
 
-
-def _make_ticker():
-    fake_mod, mock_epd = _make_mock_epd2in13_module()
     sys.modules.setdefault("epaper.lib.epdconfig", MagicMock())
-    sys.modules["epaper.lib.epd2in13_V2"] = fake_mod
+    sys.modules["epaper.lib.epd2in13_V2"] = mod
     sys.modules.pop("epaper.display", None)
 
-    with patch("epaper.display.ImageFont.truetype", return_value=MagicMock()):
-        from epaper.display import PriceTicker
-        ticker = PriceTicker(price_client=MagicMock(), price_extractor=MagicMock())
-
-    return ticker, mock_epd
+    return mock_epd_instance
 
 
-class TestPriceTickerStop(unittest.TestCase):
+class TestDisplay(unittest.TestCase):
     def setUp(self):
-        self.ticker, self.mock_epd = _make_ticker()
+        self.mock_epd = _stub_epd_module()
+        from epaper.display import Display
+        self.display = Display()
 
-    def test_stop_only_shuts_down_hardware_once(self):
-        self.ticker.stop()
-        self.ticker.stop()  # second call must be a no-op
-        self.assertEqual(self.mock_epd.sleep.call_count, 1)
+    def test_width_and_height_reflect_landscape_orientation(self):
+        # EPD.height (250) becomes display width; EPD.width (122) becomes display height
+        self.assertEqual(self.display.width, 250)
+        self.assertEqual(self.display.height, 122)
 
-    def test_stop_sets_stopped_true(self):
-        self.assertFalse(self.ticker._stopped)
-        self.ticker.stop()
-        self.assertTrue(self.ticker._stopped)
+    def test_init_calls_epd_init(self):
+        self.mock_epd.init.reset_mock()
+        self.display.init()
+        self.mock_epd.init.assert_called_once_with("FULL_UPDATE")
 
+    def test_clear_calls_epd_clear(self):
+        self.mock_epd.Clear.reset_mock()
+        self.display.clear()
+        self.mock_epd.Clear.assert_called_once_with(0xFF)
 
-class TestPriceTickerRefreshTiming(unittest.TestCase):
-    def setUp(self):
-        self.ticker, self.mock_epd = _make_ticker()
+    def test_show_passes_image_buffer_to_epd(self):
+        fake_image = MagicMock()
+        self.display.show(fake_image)
+        self.mock_epd.getbuffer.assert_called_with(fake_image)
+        self.mock_epd.display.assert_called_with(self.mock_epd.getbuffer.return_value)
 
-    def _run_tick(self, monotonic_values):
-        with patch("epaper.display.time.monotonic", side_effect=monotonic_values), \
-             patch("epaper.display.time.sleep"), \
-             patch("epaper.display.Image.new", return_value=MagicMock()), \
-             patch("epaper.display.ImageDraw.Draw", return_value=MagicMock()):
-            self.ticker.tick()
-
-    def test_first_tick_always_refreshes(self):
-        """_last_refresh starts at 0.0 so the first tick always triggers a refresh."""
-        self._run_tick([9999.0, 9999.0])
-        self.mock_epd.display.assert_called_once()
-
-    def test_no_refresh_within_interval(self):
-        """A second tick within the interval must not trigger another refresh."""
-        from epaper.display import PRICE_REFRESH_INTERVAL
-        t1 = 9999.0
-        self._run_tick([t1, t1])  # first tick: refreshes, sets _last_refresh = t1
-
-        t2 = t1 + PRICE_REFRESH_INTERVAL - 1
-        self._run_tick([t2])      # second tick: too early, no refresh
-        self.assertEqual(self.mock_epd.display.call_count, 1)
-
-    def test_refresh_after_interval_elapsed(self):
-        """A tick after the full interval must trigger a refresh."""
-        from epaper.display import PRICE_REFRESH_INTERVAL
-        t1 = 9999.0
-        self._run_tick([t1, t1])  # first tick refreshes
-
-        t2 = t1 + PRICE_REFRESH_INTERVAL
-        self._run_tick([t2, t2])  # second tick: interval elapsed, refreshes again
-        self.assertEqual(self.mock_epd.display.call_count, 2)
-
-
-class TestPriceTickerTextCentering(unittest.TestCase):
-    def setUp(self):
-        self.ticker, _ = _make_ticker()
-        self.mock_draw = MagicMock()
-        self.ticker.price_extractor.formatted_price_from_data.return_value = "$84.99k"
-
-    def test_price_drawn_at_canvas_center_with_mm_anchor(self):
-        expected_x = self.ticker.width // 2   # 125
-        expected_y = self.ticker.height // 2  # 61
-
-        with patch("epaper.display.time.monotonic", return_value=9999.0), \
-             patch("epaper.display.time.sleep"), \
-             patch("epaper.display.Image.new", return_value=MagicMock()), \
-             patch("epaper.display.ImageDraw.Draw", return_value=self.mock_draw):
-            self.ticker.tick()
-
-        self.mock_draw.text.assert_called_once()
-        args, kwargs = self.mock_draw.text.call_args
-        self.assertEqual(args[0], (expected_x, expected_y))
-        self.assertEqual(kwargs.get("anchor"), "mm")
+    def test_sleep_calls_epd_sleep(self):
+        self.mock_epd.sleep.reset_mock()
+        self.display.sleep()
+        self.mock_epd.sleep.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _make_ticker():
+    """Return a PriceTicker with a mocked Display and dummy client/extractor."""
+    mock_display = MagicMock()
+    mock_display.width = 250
+    mock_display.height = 122
+
+    with patch("epaper.ticker.ImageFont.truetype", return_value=MagicMock()):
+        from epaper.ticker import PriceTicker
+        ticker = PriceTicker(
+            display=mock_display,
+            price_client=MagicMock(),
+            price_extractor=MagicMock(),
+        )
+
+    return ticker, mock_display
+
+
+class TestPriceTickerStop(unittest.TestCase):
+    def setUp(self):
+        self.ticker, self.mock_display = _make_ticker()
+
+    def test_stop_only_shuts_down_display_once(self):
+        self.ticker.stop()
+        self.ticker.stop()  # second call must be a no-op
+        self.assertEqual(self.mock_display.sleep.call_count, 1)
+
+    def test_stop_sets_stopped_true(self):
+        self.assertFalse(self.ticker._stopped)
+        self.ticker.stop()
+        self.assertTrue(self.ticker._stopped)
+
+
+class TestPriceTickerRefreshTiming(unittest.TestCase):
+    def setUp(self):
+        self.ticker, self.mock_display = _make_ticker()
+
+    def _run_tick(self, monotonic_values):
+        with patch("epaper.ticker.time.monotonic", side_effect=monotonic_values), \
+             patch("epaper.ticker.time.sleep"), \
+             patch("epaper.ticker.Image.new", return_value=MagicMock()), \
+             patch("epaper.ticker.ImageDraw.Draw", return_value=MagicMock()):
+            self.ticker.tick()
+
+    def test_first_tick_always_refreshes(self):
+        self._run_tick([9999.0, 9999.0])
+        self.mock_display.show.assert_called_once()
+
+    def test_no_refresh_within_interval(self):
+        from epaper.ticker import PRICE_REFRESH_INTERVAL
+        t1 = 9999.0
+        self._run_tick([t1, t1])
+
+        t2 = t1 + PRICE_REFRESH_INTERVAL - 1
+        self._run_tick([t2])
+        self.assertEqual(self.mock_display.show.call_count, 1)
+
+    def test_refresh_after_interval_elapsed(self):
+        from epaper.ticker import PRICE_REFRESH_INTERVAL
+        t1 = 9999.0
+        self._run_tick([t1, t1])
+
+        t2 = t1 + PRICE_REFRESH_INTERVAL
+        self._run_tick([t2, t2])
+        self.assertEqual(self.mock_display.show.call_count, 2)
+
+
+class TestPriceTickerTextCentering(unittest.TestCase):
+    def setUp(self):
+        self.ticker, _ = _make_ticker()
+        self.mock_draw = MagicMock()
+        self.ticker.price_extractor.formatted_price_from_data.return_value = "$84.99k"
+
+    def test_price_drawn_at_canvas_center_with_mm_anchor(self):
+        expected_x = self.ticker.display.width // 2   # 125
+        expected_y = self.ticker.display.height // 2  # 61
+
+        with patch("epaper.ticker.time.monotonic", return_value=9999.0), \
+             patch("epaper.ticker.time.sleep"), \
+             patch("epaper.ticker.Image.new", return_value=MagicMock()), \
+             patch("epaper.ticker.ImageDraw.Draw", return_value=self.mock_draw):
+            self.ticker.tick()
+
+        self.mock_draw.text.assert_called_once()
+        args, kwargs = self.mock_draw.text.call_args
+        self.assertEqual(args[0], (expected_x, expected_y))
+        self.assertEqual(kwargs.get("anchor"), "mm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`display.py` previously mixed hardware management with price refresh orchestration inside `PriceTicker`. This PR splits them into two focused modules:

**`display.py` — `Display`** (hardware only)
- Wraps `epd2in13_V2` with a clean interface: `init()`, `clear()`, `show(image)`, `sleep()`, `width`, `height`
- No price logic, no timing, no PIL frame building

**`ticker.py` — `PriceTicker`** (orchestration only)
- Receives a `Display` instance — no direct EPD calls
- Handles refresh timing, price fetching, frame rendering
- Delegates all hardware operations to `Display`

**`__main__.py`** wires them together:
```python
display = Display()
ticker = PriceTicker(display, price_client, price_extractor)
```

## Test plan

- [ ] `pytest` — all 43 tests pass
- [ ] `test_display.py` — 5 tests verify hardware delegation (`init`, `clear`, `show`, `sleep`, landscape dimensions)
- [ ] `test_ticker.py` — 6 tests verify orchestration logic against a mocked `Display` (no ARM driver needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)