### PR TITLE
Make currency, symbol, and refresh interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Displays the current Bitcoin/USD price on a Waveshare 2.13" e-ink display (epd2in13 V2) connected to a Raspberry Pi. On startup it shows a Bitcoin logo, then enters a loop that refreshes the price every 5 minutes. The background alternates randomly between black and white on each refresh.
 
+## Configuration
+
+Edit `config.toml` to customise the behaviour:
+
+```toml
+[bitcoin.price]
+service_endpoint = "https://blockchain.info/ticker"
+currency = "USD"   # currency code returned by the API (e.g. "CHF")
+symbol = "$"       # symbol shown on the display (e.g. "CHF")
+refresh_interval = 300  # seconds between price refreshes
+```
+
 ## Requirements
 
 - Raspberry Pi (tested on Pi 5)

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,8 @@
 [bitcoin.price]
 service_endpoint = "https://blockchain.info/ticker"
+currency = "USD"
+symbol = "$"
+refresh_interval = 300  # seconds
 
 [gpiozero]
 pin_factory = "pigpio"

--- a/src/epaper/__main__.py
+++ b/src/epaper/__main__.py
@@ -19,10 +19,15 @@ logging.basicConfig(level=logging.INFO)
 
 
 def main() -> None:
+    cfg = config().get("bitcoin", {}).get("price", {})
+    currency = cfg.get("currency", "USD")
+    symbol = cfg.get("symbol", "$")
+    refresh_interval = cfg.get("refresh_interval", 300)
+
     display = Display()
     price_client = BitcoinPriceClient()
-    price_extractor = PriceExtractor("USD", "$")
-    ticker = PriceTicker(display, price_client, price_extractor)
+    price_extractor = PriceExtractor(currency, symbol)
+    ticker = PriceTicker(display, price_client, price_extractor, refresh_interval)
     shutdown = GracefulShutdown()
 
     try:

--- a/src/epaper/price_ticker.py
+++ b/src/epaper/price_ticker.py
@@ -12,7 +12,7 @@ _MEDIA_DIR = Path(__file__).parent / "media"
 FONT_FILE = _MEDIA_DIR / "UbuntuBoldItalic-Rg86.ttf"
 IMAGE_FILE = _MEDIA_DIR / "bitcoin122x122_b.bmp"
 FONT_SIZE = 48  # 48 points = 64 pixels
-PRICE_REFRESH_INTERVAL = 300  # seconds
+DEFAULT_REFRESH_INTERVAL = 300  # seconds
 
 WHITE = 255
 BLACK = 0
@@ -25,10 +25,11 @@ class PriceTicker:
     all hardware operations to the Display instance.
     """
 
-    def __init__(self, display: Display, price_client, price_extractor) -> None:
+    def __init__(self, display: Display, price_client, price_extractor, refresh_interval: int = DEFAULT_REFRESH_INTERVAL) -> None:
         self.display = display
         self.price_client = price_client
         self.price_extractor = price_extractor
+        self._refresh_interval = refresh_interval
         self._stopped = False
         self._last_refresh = 0.0  # triggers refresh on first tick()
         self._font = ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
@@ -44,7 +45,7 @@ class PriceTicker:
 
     def tick(self) -> None:
         """Run one iteration of the price refresh loop. Call repeatedly from main."""
-        if time.monotonic() - self._last_refresh >= PRICE_REFRESH_INTERVAL:
+        if time.monotonic() - self._last_refresh >= self._refresh_interval:
             self.display.init()
             self.display.clear()
 

--- a/tests/test_price_ticker.py
+++ b/tests/test_price_ticker.py
@@ -50,20 +50,20 @@ class TestPriceTickerRefreshTiming(unittest.TestCase):
         self.mock_display.show.assert_called_once()
 
     def test_no_refresh_within_interval(self):
-        from epaper.price_ticker import PRICE_REFRESH_INTERVAL
+        from epaper.price_ticker import DEFAULT_REFRESH_INTERVAL
         t1 = 9999.0
         self._run_tick([t1, t1])
 
-        t2 = t1 + PRICE_REFRESH_INTERVAL - 1
+        t2 = t1 + DEFAULT_REFRESH_INTERVAL - 1
         self._run_tick([t2])
         self.assertEqual(self.mock_display.show.call_count, 1)
 
     def test_refresh_after_interval_elapsed(self):
-        from epaper.price_ticker import PRICE_REFRESH_INTERVAL
+        from epaper.price_ticker import DEFAULT_REFRESH_INTERVAL
         t1 = 9999.0
         self._run_tick([t1, t1])
 
-        t2 = t1 + PRICE_REFRESH_INTERVAL
+        t2 = t1 + DEFAULT_REFRESH_INTERVAL
         self._run_tick([t2, t2])
         self.assertEqual(self.mock_display.show.call_count, 2)
 


### PR DESCRIPTION
## Summary
- Adds `currency`, `symbol`, and `refresh_interval` to `config.toml`
- `__main__.py` reads these values and passes them to `PriceExtractor` and `PriceTicker`
- `PriceTicker` accepts `refresh_interval` as a constructor parameter (defaults to `DEFAULT_REFRESH_INTERVAL = 300`)
- `README.md` documents the new config options

## Test plan
- [ ] All 43 existing tests pass
- [ ] Change `currency`/`symbol` in `config.toml` to `CHF`/`CHF` and verify display shows CHF price
- [ ] Change `refresh_interval` to a lower value and verify faster refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)