### PR TITLE
Remove redundant clear() before each price refresh

### DIFF
--- a/src/epaper/price_ticker.py
+++ b/src/epaper/price_ticker.py
@@ -47,7 +47,6 @@ class PriceTicker:
         """Run one iteration of the price refresh loop. Call repeatedly from main."""
         if time.monotonic() - self._last_refresh >= self._refresh_interval:
             self.display.init()
-            self.display.clear()
 
             bg = random.choice([BLACK, WHITE])
             fg = WHITE if bg == BLACK else BLACK


### PR DESCRIPTION
## Summary
- Removes the `self.display.clear()` call inside `tick()` before rendering each price frame
- The full refresh waveform already resets every pixel as part of displaying the new image, so the explicit clear was causing an extra flicker per update with no benefit
- Halves the number of full refresh cycles per price update (2 → 1)

## Test plan
- [ ] All 43 tests pass (no test relied on `clear` being called in `tick`)
- [ ] Verify on device that price updates still render cleanly without ghosting

🤖 Generated with [Claude Code](https://claude.com/claude-code)