### PR TITLE
Update service paths to e-paper directory

### DIFF
--- a/systemd/epaper.service
+++ b/systemd/epaper.service
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 User=pi
-WorkingDirectory=/home/pi/epaper
-ExecStart=/home/pi/epaper/.venv/bin/python -m epaper
+WorkingDirectory=/home/pi/e-paper
+ExecStart=/home/pi/e-paper/.venv/bin/python -m epaper
 Restart=on-failure
 RestartSec=10
 Type=notify


### PR DESCRIPTION
## Summary
- Updates `WorkingDirectory` and `ExecStart` in `systemd/epaper.service` to point to `~/e-paper` instead of `~/epaper`

## Test plan
- [ ] Move directory on Pi: `mv ~/epaper ~/e-paper`
- [ ] Deploy updated service file: `sudo cp ~/e-paper/systemd/epaper.service /etc/systemd/system/`
- [ ] Reload and restart: `sudo systemctl daemon-reload && sudo systemctl restart epaper`
- [ ] Verify service is running: `systemctl status epaper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)