### PR TITLE
Apply Python 3.13.5 language features

### DIFF
--- a/src/epaper/config.py
+++ b/src/epaper/config.py
@@ -1,5 +1,5 @@
 import tomllib
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 
 # Prefer config.toml next to the current working directory (production: the
@@ -9,7 +9,7 @@ _REPO_CONFIG = Path(__file__).parents[2] / "config.toml"
 _CONFIG_PATH = _CWD_CONFIG if _CWD_CONFIG.exists() else _REPO_CONFIG
 
 
-@lru_cache(maxsize=None)
+@cache
 def config() -> dict:
     with open(_CONFIG_PATH, "rb") as f:
         return tomllib.load(f)

--- a/src/epaper/price/price_extractor.py
+++ b/src/epaper/price/price_extractor.py
@@ -1,12 +1,14 @@
 import math
 
+type PriceData = dict | None
+
 
 class PriceExtractor:
     def __init__(self, currency: str, symbol: str) -> None:
         self.currency = currency
         self.symbol = symbol
 
-    def formatted_price_from_data(self, data: dict | None) -> str:
+    def formatted_price_from_data(self, data: PriceData) -> str:
         if not data:
             return "N/A"
         currency_data = data.get(self.currency)
@@ -18,19 +20,20 @@ class PriceExtractor:
         return self.format_price(price)
 
     def format_price(self, price: float) -> str:
-        price_without_cents = self.price_without_cents(price)
-        if price_without_cents >= 100_000:
-            value = price_without_cents / 1_000_000
-            truncated = int(value * 1000) / 1000  # truncate to 3 decimal places, no rounding
-            formatted = f"{truncated:.3f}".rstrip("0").rstrip(".")
-            return f'{self.symbol}{formatted.lstrip("0")}M'
-        elif price_without_cents >= 1_000:
-            value = price_without_cents / 1_000
-            truncated = int(value * 100) / 100  # truncate to 2 decimal places, no rounding
-            formatted = f"{truncated:.2f}".rstrip("0").rstrip(".")
-            return f"{self.symbol}{formatted}k"
-        else:
-            return f"{self.symbol}{int(price_without_cents)}"
+        p = self.price_without_cents(price)
+        match p:
+            case p if p >= 100_000:
+                value = p / 1_000_000
+                truncated = int(value * 1000) / 1000  # truncate to 3 decimal places, no rounding
+                formatted = f"{truncated:.3f}".rstrip("0").rstrip(".")
+                return f'{self.symbol}{formatted.lstrip("0")}M'
+            case p if p >= 1_000:
+                value = p / 1_000
+                truncated = int(value * 100) / 100  # truncate to 2 decimal places, no rounding
+                formatted = f"{truncated:.2f}".rstrip("0").rstrip(".")
+                return f"{self.symbol}{formatted}k"
+            case p:
+                return f"{self.symbol}{p}"
 
-    def price_without_cents(self, price: float) -> float:
-        return float(math.floor(price))
+    def price_without_cents(self, price: float) -> int:
+        return math.floor(price)

--- a/src/epaper/price_ticker.py
+++ b/src/epaper/price_ticker.py
@@ -2,10 +2,19 @@ import logging
 import random
 import time
 from pathlib import Path
+from typing import Protocol
 
 from PIL import Image, ImageDraw, ImageFont
 
 from epaper.display import Display
+
+
+class PriceClient(Protocol):
+    def retrieve_data(self) -> dict | None: ...
+
+
+class PriceExtractor(Protocol):
+    def formatted_price_from_data(self, data: dict | None) -> str: ...
 
 _MEDIA_DIR = Path(__file__).parent / "media"
 
@@ -25,7 +34,7 @@ class PriceTicker:
     all hardware operations to the Display instance.
     """
 
-    def __init__(self, display: Display, price_client, price_extractor, refresh_interval: int = DEFAULT_REFRESH_INTERVAL) -> None:
+    def __init__(self, display: Display, price_client: PriceClient, price_extractor: PriceExtractor, refresh_interval: int = DEFAULT_REFRESH_INTERVAL) -> None:
         self.display = display
         self.price_client = price_client
         self.price_extractor = price_extractor

--- a/tests/test_bitcoin_price_client.py
+++ b/tests/test_bitcoin_price_client.py
@@ -13,7 +13,7 @@ FIXTURE = Path(__file__).parent / "mock_data.json"
 
 
 class TestPriceExtractorIntegration(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.data = BitcoinPriceClientMock(FIXTURE).retrieve_data()
 
     def test_format_usd_price(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,7 @@ class TestConfigLoader(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertIn("bitcoin", result)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         sys.modules.pop("epaper.config", None)
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -22,7 +22,7 @@ def _stub_epd_module():
 
 
 class TestDisplay(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.mock_epd = _stub_epd_module()
         from epaper.display import Display
         self.display = Display()

--- a/tests/test_price_extractor.py
+++ b/tests/test_price_extractor.py
@@ -4,7 +4,7 @@ from epaper.price.price_extractor import PriceExtractor
 
 
 class TestPriceExtractor(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.extractor = PriceExtractor(currency="USD", symbol="$")
 
     def test_format_price_in_millions(self):

--- a/tests/test_price_ticker.py
+++ b/tests/test_price_ticker.py
@@ -20,7 +20,7 @@ def _make_ticker():
 
 
 class TestPriceTickerStop(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.ticker, self.mock_display = _make_ticker()
 
     def test_stop_only_shuts_down_display_once(self):
@@ -35,7 +35,7 @@ class TestPriceTickerStop(unittest.TestCase):
 
 
 class TestPriceTickerRefreshTiming(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.ticker, self.mock_display = _make_ticker()
 
     def _run_tick(self, monotonic_values):
@@ -69,7 +69,7 @@ class TestPriceTickerRefreshTiming(unittest.TestCase):
 
 
 class TestPriceTickerTextCentering(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.ticker, _ = _make_ticker()
         self.mock_draw = MagicMock()
         self.ticker.price_extractor.formatted_price_from_data.return_value = "$84.99k"


### PR DESCRIPTION
## Summary

- Replace `lru_cache(maxsize=None)` with `functools.cache` — the simpler 3.9+ alias
- Add `type PriceData = dict | None` alias using the `type` statement (3.12+)
- Refactor `format_price` if/elif/else to `match` statement (3.10+)
- Fix `price_without_cents` return type `float` → `int` (`math.floor` returns `int` in Python 3)
- Add `PriceClient` / `PriceExtractor` `Protocol` types in `price_ticker.py` to make duck-typed params explicit
- Add `-> None` return annotations to all `setUp` / `tearDown` test methods

## Test plan

- [x] All 43 existing tests pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)