### PR TITLE
Improve documentation across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,28 @@ Edit `config.toml` to customise the behaviour:
 ```toml
 [bitcoin.price]
 service_endpoint = "https://blockchain.info/ticker"
-currency = "USD"   # currency code returned by the API (e.g. "CHF")
-symbol = "$"       # symbol shown on the display (e.g. "CHF")
+currency = "USD"   # currency code returned by the API (e.g. "CHF", "EUR")
+symbol = "$"       # symbol shown on the display (e.g. "CHF ", "€")
 refresh_interval = 300  # seconds between price refreshes
 ```
+
+**To display a different currency**, set `currency` to any code the API returns and `symbol` to the label you want shown on screen. For example, to show Swiss francs:
+
+```toml
+currency = "CHF"
+symbol = "CHF "
+```
+
+The `service_endpoint` must return JSON in this shape (the [blockchain.info ticker](https://blockchain.info/ticker) is the default):
+
+```json
+{
+  "USD": { "last": 84500.0, ... },
+  "CHF": { "last": 75000.0, ... }
+}
+```
+
+Any endpoint that returns this structure works as a drop-in replacement.
 
 ## Requirements
 
@@ -34,7 +52,18 @@ If you get permission errors on SPI/GPIO devices, add your user to the required 
 sudo usermod -aG spi,gpio $USER
 ```
 
+## Development
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+pytest
+```
+
 ## Run as a systemd service (auto-start on boot, auto-restart on failure)
+
+Open `systemd/epaper.service` and adjust `User`, `WorkingDirectory`, and `ExecStart` to match your username and install path before copying it.
 
 ```bash
 # Install the service unit

--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,11 @@
 [bitcoin.price]
 service_endpoint = "https://blockchain.info/ticker"
-currency = "USD"
-symbol = "$"
-refresh_interval = 300  # seconds
+currency = "USD"          # currency code returned by the API (e.g. "CHF", "EUR")
+symbol = "$"              # symbol shown on the display (e.g. "CHF ", "€")
+refresh_interval = 300    # seconds between price refreshes
 
 [gpiozero]
+# GPIO backend used by gpiozero to drive the SPI/GPIO pins.
+# "pigpio" is recommended for Raspberry Pi (requires the pigpiod daemon).
+# Other valid values: "rpigpio", "native". See gpiozero docs for details.
 pin_factory = "pigpio"

--- a/src/epaper/__main__.py
+++ b/src/epaper/__main__.py
@@ -6,6 +6,8 @@ import traceback
 
 from epaper.config import config
 
+# GPIOZERO_PIN_FACTORY must be set before Display is imported, because gpiozero
+# reads the env var at import time to select the GPIO backend.
 os.environ.setdefault("GPIOZERO_PIN_FACTORY", config().get("gpiozero", {}).get("pin_factory", "pigpio"))
 
 from epaper.display import Display

--- a/src/epaper/http_client.py
+++ b/src/epaper/http_client.py
@@ -7,6 +7,9 @@ DEFAULT_TIMEOUT = 10  # seconds
 
 
 class HttpClient:
+    """Thin wrapper around requests that enforces a timeout and raises
+    ConnectionError for any non-2xx response."""
+
     def __init__(self, timeout: int = DEFAULT_TIMEOUT) -> None:
         self.timeout = timeout
 

--- a/src/epaper/price/bitcoin_price_client.py
+++ b/src/epaper/price/bitcoin_price_client.py
@@ -12,7 +12,17 @@ RETRY_DELAY = 5  # seconds between attempts
 
 
 class BitcoinPriceClient:
+    """Fetches the current Bitcoin price from the configured ticker endpoint.
+
+    The endpoint is expected to return a JSON object keyed by currency code,
+    e.g. {"USD": {"last": 84500.0, ...}, "CHF": {"last": 75000.0, ...}}.
+    """
+
     def retrieve_data(self) -> dict | None:
+        """Fetch price data, retrying up to MAX_RETRIES times on failure.
+
+        Returns the parsed JSON dict on success, or None if all attempts fail.
+        """
         endpoint = config()["bitcoin"]["price"]["service_endpoint"]
         for attempt in range(1, MAX_RETRIES + 1):
             try:

--- a/src/epaper/price/price_extractor.py
+++ b/src/epaper/price/price_extractor.py
@@ -20,6 +20,16 @@ class PriceExtractor:
         return self.format_price(price)
 
     def format_price(self, price: float) -> str:
+        """Format a price for display on the e-paper screen.
+
+        Thresholds (applied to the whole-dollar value, cents stripped):
+          >= 100,000 → millions, e.g. "$1.234M" or "$.1M"
+          >=   1,000 → thousands, e.g. "$84.99k" or "$50k"
+          <    1,000 → raw integer, e.g. "$999"
+
+        Trailing zeros are stripped. Values are truncated, never rounded,
+        so the display never shows a price higher than the actual value.
+        """
         p = self.price_without_cents(price)
         match p:
             case p if p >= 100_000:

--- a/systemd/epaper.service
+++ b/systemd/epaper.service
@@ -4,6 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+# Adjust User, WorkingDirectory, and ExecStart to match your install location.
 User=pi
 WorkingDirectory=/home/pi/e-paper
 ExecStart=/home/pi/e-paper/.venv/bin/python -m epaper


### PR DESCRIPTION
## Summary

**Critical fixes**
- README: add a Development section with venv setup and `pytest` instructions
- README: warn that `systemd/epaper.service` needs path/user customisation before use
- `systemd/epaper.service`: add inline comment flagging the hardcoded `User` and paths
- `config.toml`: fully document the `[gpiozero]` section (valid values, pigpiod requirement)

**Suggestions**
- README: add a currency-switching how-to and the expected API response shape
- `config.toml`: inline comments on all `bitcoin.price` fields
- `HttpClient`: class docstring documenting the non-2xx → `ConnectionError` contract
- `BitcoinPriceClient`: class docstring with API response shape; method docstring with return contract (`dict` vs `None`)
- `PriceExtractor.format_price`: docstring covering threshold rules and truncation-not-rounding policy
- `__main__.py`: comment explaining why `GPIOZERO_PIN_FACTORY` must be set before `Display` is imported

## Test plan

- [x] All 43 tests pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)