### PR TITLE
Add pre-commit hook with ruff linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ rpi = [
 ]
 dev = [
     "pytest>=8.0.0",
+    "pre-commit>=4.0.0",
+    "ruff>=0.11.2",
 ]
 
 [project.scripts]
@@ -35,3 +37,23 @@ packages = ["src/epaper"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+exclude = ["src/epaper/lib"]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "W",   # pycodestyle warnings
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "SIM", # flake8-simplify
+]
+ignore = [
+    "E501", # line-length enforced by formatter, not linter
+]

--- a/src/epaper/__main__.py
+++ b/src/epaper/__main__.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import signal
 import sys
 import traceback
 
@@ -8,7 +7,9 @@ from epaper.config import config
 
 # GPIOZERO_PIN_FACTORY must be set before Display is imported, because gpiozero
 # reads the env var at import time to select the GPIO backend.
-os.environ.setdefault("GPIOZERO_PIN_FACTORY", config().get("gpiozero", {}).get("pin_factory", "pigpio"))
+os.environ.setdefault(
+    "GPIOZERO_PIN_FACTORY", config().get("gpiozero", {}).get("pin_factory", "pigpio")
+)
 
 from epaper.display import Display
 from epaper.price.bitcoin_price_client import BitcoinPriceClient

--- a/src/epaper/display.py
+++ b/src/epaper/display.py
@@ -27,8 +27,8 @@ class Display:
         self._epd = epd2in13_V2.EPD()
         self._epd.init(self._epd.FULL_UPDATE)
         self._epd.Clear(0xFF)
-        self.width = self._epd.height   # 250 pixels
-        self.height = self._epd.width   # 122 pixels
+        self.width = self._epd.height  # 250 pixels
+        self.height = self._epd.width  # 122 pixels
 
     def init(self) -> None:
         self._epd.init(self._epd.FULL_UPDATE)

--- a/src/epaper/http_client.py
+++ b/src/epaper/http_client.py
@@ -2,7 +2,6 @@ import json
 
 import requests
 
-
 DEFAULT_TIMEOUT = 10  # seconds
 
 

--- a/src/epaper/price/bitcoin_price_client.py
+++ b/src/epaper/price/bitcoin_price_client.py
@@ -29,8 +29,14 @@ class BitcoinPriceClient:
                 result = HttpClient().get(endpoint)
                 if result:
                     return json.loads(result)
-            except (ConnectionError, requests.RequestException, json.JSONDecodeError) as e:
-                logging.warning("Price fetch attempt %d/%d failed: %s", attempt, MAX_RETRIES, e)
+            except (
+                ConnectionError,
+                requests.RequestException,
+                json.JSONDecodeError,
+            ) as e:
+                logging.warning(
+                    "Price fetch attempt %d/%d failed: %s", attempt, MAX_RETRIES, e
+                )
                 if attempt < MAX_RETRIES:
                     time.sleep(RETRY_DELAY)
         logging.error("All %d price fetch attempts failed", MAX_RETRIES)

--- a/src/epaper/price/price_extractor.py
+++ b/src/epaper/price/price_extractor.py
@@ -34,12 +34,16 @@ class PriceExtractor:
         match p:
             case p if p >= 100_000:
                 value = p / 1_000_000
-                truncated = int(value * 1000) / 1000  # truncate to 3 decimal places, no rounding
+                truncated = (
+                    int(value * 1000) / 1000
+                )  # truncate to 3 decimal places, no rounding
                 formatted = f"{truncated:.3f}".rstrip("0").rstrip(".")
-                return f'{self.symbol}{formatted.lstrip("0")}M'
+                return f"{self.symbol}{formatted.lstrip('0')}M"
             case p if p >= 1_000:
                 value = p / 1_000
-                truncated = int(value * 100) / 100  # truncate to 2 decimal places, no rounding
+                truncated = (
+                    int(value * 100) / 100
+                )  # truncate to 2 decimal places, no rounding
                 formatted = f"{truncated:.2f}".rstrip("0").rstrip(".")
                 return f"{self.symbol}{formatted}k"
             case p:

--- a/src/epaper/price_ticker.py
+++ b/src/epaper/price_ticker.py
@@ -16,6 +16,7 @@ class PriceClient(Protocol):
 class PriceExtractor(Protocol):
     def formatted_price_from_data(self, data: dict | None) -> str: ...
 
+
 _MEDIA_DIR = Path(__file__).parent / "media"
 
 FONT_FILE = _MEDIA_DIR / "UbuntuBoldItalic-Rg86.ttf"
@@ -34,7 +35,13 @@ class PriceTicker:
     all hardware operations to the Display instance.
     """
 
-    def __init__(self, display: Display, price_client: PriceClient, price_extractor: PriceExtractor, refresh_interval: int = DEFAULT_REFRESH_INTERVAL) -> None:
+    def __init__(
+        self,
+        display: Display,
+        price_client: PriceClient,
+        price_extractor: PriceExtractor,
+        refresh_interval: int = DEFAULT_REFRESH_INTERVAL,
+    ) -> None:
         self.display = display
         self.price_client = price_client
         self.price_extractor = price_extractor

--- a/src/epaper/utils/graceful_shutdown.py
+++ b/src/epaper/utils/graceful_shutdown.py
@@ -32,5 +32,7 @@ class GracefulShutdown:
         signal.signal(signal.SIGTERM, self._exit)
 
     def _exit(self, signum: int, frame: FrameType | None) -> None:
-        print(f"Received signal {signum}, shutting down...")  # logging isn't fully reentrant inside signal handlers
+        print(
+            f"Received signal {signum}, shutting down..."
+        )  # logging isn't fully reentrant inside signal handlers
         self.kill_now = True

--- a/tests/test_bitcoin_price_client.py
+++ b/tests/test_bitcoin_price_client.py
@@ -1,13 +1,17 @@
 import json
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch
 
 import requests
 
-from epaper.price.bitcoin_price_client import BitcoinPriceClient, MAX_RETRIES, RETRY_DELAY
-from epaper.price.price_extractor import PriceExtractor
+from epaper.price.bitcoin_price_client import (
+    MAX_RETRIES,
+    RETRY_DELAY,
+    BitcoinPriceClient,
+)
 from epaper.price.mock import BitcoinPriceClientMock
+from epaper.price.price_extractor import PriceExtractor
 
 FIXTURE = Path(__file__).parent / "mock_data.json"
 
@@ -36,8 +40,10 @@ class TestPriceExtractorIntegration(unittest.TestCase):
 
 class TestBitcoinPriceClientErrorHandling(unittest.TestCase):
     def _run_with_error(self, side_effect):
-        with patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp, \
-             patch("epaper.price.bitcoin_price_client.time.sleep"):
+        with (
+            patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp,
+            patch("epaper.price.bitcoin_price_client.time.sleep"),
+        ):
             MockHttp.return_value.get.side_effect = side_effect
             return BitcoinPriceClient().retrieve_data()
 
@@ -48,11 +54,15 @@ class TestBitcoinPriceClientErrorHandling(unittest.TestCase):
         self.assertIsNone(self._run_with_error(requests.Timeout("timed out")))
 
     def test_requests_exception_returns_none(self):
-        self.assertIsNone(self._run_with_error(requests.RequestException("network error")))
+        self.assertIsNone(
+            self._run_with_error(requests.RequestException("network error"))
+        )
 
     def test_malformed_json_returns_none(self):
-        with patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp, \
-             patch("epaper.price.bitcoin_price_client.time.sleep"):
+        with (
+            patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp,
+            patch("epaper.price.bitcoin_price_client.time.sleep"),
+        ):
             MockHttp.return_value.get.return_value = "not valid json {"
             self.assertIsNone(BitcoinPriceClient().retrieve_data())
 
@@ -60,8 +70,10 @@ class TestBitcoinPriceClientErrorHandling(unittest.TestCase):
 class TestBitcoinPriceClientRetry(unittest.TestCase):
     def test_succeeds_on_first_attempt_without_retrying(self):
         good_response = json.dumps({"USD": {"last": 50000}})
-        with patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp, \
-             patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep:
+        with (
+            patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp,
+            patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep,
+        ):
             MockHttp.return_value.get.return_value = good_response
             result = BitcoinPriceClient().retrieve_data()
 
@@ -70,8 +82,10 @@ class TestBitcoinPriceClientRetry(unittest.TestCase):
 
     def test_retries_on_failure_and_returns_data_on_success(self):
         good_response = json.dumps({"USD": {"last": 50000}})
-        with patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp, \
-             patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep:
+        with (
+            patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp,
+            patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep,
+        ):
             # Fail twice, succeed on third attempt
             MockHttp.return_value.get.side_effect = [
                 ConnectionError("fail"),
@@ -85,18 +99,24 @@ class TestBitcoinPriceClientRetry(unittest.TestCase):
         mock_sleep.assert_called_with(RETRY_DELAY)
 
     def test_exhausts_all_retries_and_returns_none(self):
-        with patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp, \
-             patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep:
+        with (
+            patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp,
+            patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep,
+        ):
             MockHttp.return_value.get.side_effect = ConnectionError("always fails")
             result = BitcoinPriceClient().retrieve_data()
 
         self.assertIsNone(result)
         self.assertEqual(MockHttp.return_value.get.call_count, MAX_RETRIES)
-        self.assertEqual(mock_sleep.call_count, MAX_RETRIES - 1)  # no sleep after last attempt
+        self.assertEqual(
+            mock_sleep.call_count, MAX_RETRIES - 1
+        )  # no sleep after last attempt
 
     def test_no_sleep_after_last_failed_attempt(self):
-        with patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp, \
-             patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep:
+        with (
+            patch("epaper.price.bitcoin_price_client.HttpClient") as MockHttp,
+            patch("epaper.price.bitcoin_price_client.time.sleep") as mock_sleep,
+        ):
             MockHttp.return_value.get.side_effect = ConnectionError("fail")
             BitcoinPriceClient().retrieve_data()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,15 +4,15 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-
 _REAL_CONFIG = Path(__file__).parents[1] / "config.toml"
-_MINIMAL_TOML = b"[bitcoin.price]\nservice_endpoint = \"http://example.com\"\n"
+_MINIMAL_TOML = b'[bitcoin.price]\nservice_endpoint = "http://example.com"\n'
 
 
 class TestConfigLoader(unittest.TestCase):
     def _fresh_config_module(self):
         sys.modules.pop("epaper.config", None)
         import epaper.config
+
         return epaper.config
 
     def test_loads_from_cwd_when_config_toml_present(self):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -25,6 +25,7 @@ class TestDisplay(unittest.TestCase):
     def setUp(self) -> None:
         self.mock_epd = _stub_epd_module()
         from epaper.display import Display
+
         self.display = Display()
 
     def test_width_and_height_reflect_landscape_orientation(self):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,7 +1,7 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-from epaper.http_client import HttpClient, DEFAULT_TIMEOUT
+from epaper.http_client import DEFAULT_TIMEOUT, HttpClient
 
 
 class TestHttpClientStatusCodes(unittest.TestCase):
@@ -13,18 +13,31 @@ class TestHttpClientStatusCodes(unittest.TestCase):
 
     def test_2xx_codes_do_not_raise(self):
         for code in (200, 201, 204, 206):
-            with patch("epaper.http_client.requests.get", return_value=self._mock_response(code)):
+            with patch(
+                "epaper.http_client.requests.get",
+                return_value=self._mock_response(code),
+            ):
                 HttpClient().get("http://example.com")  # must not raise
 
     def test_4xx_raises_connection_error(self):
-        with patch("epaper.http_client.requests.get", return_value=self._mock_response(404)):
-            with self.assertRaises(ConnectionError):
-                HttpClient().get("http://example.com")
+        with (
+            patch(
+                "epaper.http_client.requests.get",
+                return_value=self._mock_response(404),
+            ),
+            self.assertRaises(ConnectionError),
+        ):
+            HttpClient().get("http://example.com")
 
     def test_5xx_raises_connection_error(self):
-        with patch("epaper.http_client.requests.get", return_value=self._mock_response(500)):
-            with self.assertRaises(ConnectionError):
-                HttpClient().get("http://example.com")
+        with (
+            patch(
+                "epaper.http_client.requests.get",
+                return_value=self._mock_response(500),
+            ),
+            self.assertRaises(ConnectionError),
+        ):
+            HttpClient().get("http://example.com")
 
 
 class TestHttpClientTimeout(unittest.TestCase):
@@ -35,35 +48,56 @@ class TestHttpClientTimeout(unittest.TestCase):
         return mock
 
     def test_get_passes_default_timeout(self):
-        with patch("epaper.http_client.requests.get", return_value=self._mock_response()) as mock_get:
+        with patch(
+            "epaper.http_client.requests.get", return_value=self._mock_response()
+        ) as mock_get:
             HttpClient().get("http://example.com")
-            mock_get.assert_called_once_with("http://example.com", timeout=DEFAULT_TIMEOUT)
+            mock_get.assert_called_once_with(
+                "http://example.com", timeout=DEFAULT_TIMEOUT
+            )
 
     def test_post_passes_default_timeout(self):
-        with patch("epaper.http_client.requests.post", return_value=self._mock_response()) as mock_post:
+        with patch(
+            "epaper.http_client.requests.post", return_value=self._mock_response()
+        ) as mock_post:
             HttpClient().post("http://example.com")
-            mock_post.assert_called_once_with("http://example.com", data=None, timeout=DEFAULT_TIMEOUT)
+            mock_post.assert_called_once_with(
+                "http://example.com", data=None, timeout=DEFAULT_TIMEOUT
+            )
 
     def test_put_passes_default_timeout(self):
-        with patch("epaper.http_client.requests.put", return_value=self._mock_response()) as mock_put:
+        with patch(
+            "epaper.http_client.requests.put", return_value=self._mock_response()
+        ) as mock_put:
             HttpClient().put("http://example.com")
-            mock_put.assert_called_once_with("http://example.com", data=None, timeout=DEFAULT_TIMEOUT)
+            mock_put.assert_called_once_with(
+                "http://example.com", data=None, timeout=DEFAULT_TIMEOUT
+            )
 
     def test_delete_passes_default_timeout(self):
-        with patch("epaper.http_client.requests.delete", return_value=self._mock_response()) as mock_delete:
+        with patch(
+            "epaper.http_client.requests.delete", return_value=self._mock_response()
+        ) as mock_delete:
             HttpClient().delete("http://example.com")
-            mock_delete.assert_called_once_with("http://example.com", timeout=DEFAULT_TIMEOUT)
+            mock_delete.assert_called_once_with(
+                "http://example.com", timeout=DEFAULT_TIMEOUT
+            )
 
     def test_custom_timeout_is_used(self):
-        with patch("epaper.http_client.requests.get", return_value=self._mock_response()) as mock_get:
+        with patch(
+            "epaper.http_client.requests.get", return_value=self._mock_response()
+        ) as mock_get:
             HttpClient(timeout=30).get("http://example.com")
             mock_get.assert_called_once_with("http://example.com", timeout=30)
 
     def test_timeout_raises_connection_error(self):
         import requests as req
-        with patch("epaper.http_client.requests.get", side_effect=req.Timeout):
-            with self.assertRaises(req.Timeout):
-                HttpClient().get("http://example.com")
+
+        with (
+            patch("epaper.http_client.requests.get", side_effect=req.Timeout),
+            self.assertRaises(req.Timeout),
+        ):
+            HttpClient().get("http://example.com")
 
 
 if __name__ == "__main__":

--- a/tests/test_price_extractor.py
+++ b/tests/test_price_extractor.py
@@ -28,11 +28,15 @@ class TestPriceExtractor(unittest.TestCase):
 
     def test_unknown_currency_returns_na(self):
         extractor = PriceExtractor("XYZ", "X")
-        self.assertEqual(extractor.formatted_price_from_data({"USD": {"last": 50000}}), "N/A")
+        self.assertEqual(
+            extractor.formatted_price_from_data({"USD": {"last": 50000}}), "N/A"
+        )
 
     def test_missing_last_key_returns_na(self):
         extractor = PriceExtractor("USD", "$")
-        self.assertEqual(extractor.formatted_price_from_data({"USD": {"buy": 50000}}), "N/A")
+        self.assertEqual(
+            extractor.formatted_price_from_data({"USD": {"buy": 50000}}), "N/A"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_price_ticker.py
+++ b/tests/test_price_ticker.py
@@ -10,6 +10,7 @@ def _make_ticker():
 
     with patch("epaper.price_ticker.ImageFont.truetype", return_value=MagicMock()):
         from epaper.price_ticker import PriceTicker
+
         ticker = PriceTicker(
             display=mock_display,
             price_client=MagicMock(),
@@ -39,10 +40,12 @@ class TestPriceTickerRefreshTiming(unittest.TestCase):
         self.ticker, self.mock_display = _make_ticker()
 
     def _run_tick(self, monotonic_values):
-        with patch("epaper.price_ticker.time.monotonic", side_effect=monotonic_values), \
-             patch("epaper.price_ticker.time.sleep"), \
-             patch("epaper.price_ticker.Image.new", return_value=MagicMock()), \
-             patch("epaper.price_ticker.ImageDraw.Draw", return_value=MagicMock()):
+        with (
+            patch("epaper.price_ticker.time.monotonic", side_effect=monotonic_values),
+            patch("epaper.price_ticker.time.sleep"),
+            patch("epaper.price_ticker.Image.new", return_value=MagicMock()),
+            patch("epaper.price_ticker.ImageDraw.Draw", return_value=MagicMock()),
+        ):
             self.ticker.tick()
 
     def test_first_tick_always_refreshes(self):
@@ -51,6 +54,7 @@ class TestPriceTickerRefreshTiming(unittest.TestCase):
 
     def test_no_refresh_within_interval(self):
         from epaper.price_ticker import DEFAULT_REFRESH_INTERVAL
+
         t1 = 9999.0
         self._run_tick([t1, t1])
 
@@ -60,6 +64,7 @@ class TestPriceTickerRefreshTiming(unittest.TestCase):
 
     def test_refresh_after_interval_elapsed(self):
         from epaper.price_ticker import DEFAULT_REFRESH_INTERVAL
+
         t1 = 9999.0
         self._run_tick([t1, t1])
 
@@ -75,13 +80,15 @@ class TestPriceTickerTextCentering(unittest.TestCase):
         self.ticker.price_extractor.formatted_price_from_data.return_value = "$84.99k"
 
     def test_price_drawn_at_canvas_center_with_mm_anchor(self):
-        expected_x = self.ticker.display.width // 2   # 125
+        expected_x = self.ticker.display.width // 2  # 125
         expected_y = self.ticker.display.height // 2  # 61
 
-        with patch("epaper.price_ticker.time.monotonic", return_value=9999.0), \
-             patch("epaper.price_ticker.time.sleep"), \
-             patch("epaper.price_ticker.Image.new", return_value=MagicMock()), \
-             patch("epaper.price_ticker.ImageDraw.Draw", return_value=self.mock_draw):
+        with (
+            patch("epaper.price_ticker.time.monotonic", return_value=9999.0),
+            patch("epaper.price_ticker.time.sleep"),
+            patch("epaper.price_ticker.Image.new", return_value=MagicMock()),
+            patch("epaper.price_ticker.ImageDraw.Draw", return_value=self.mock_draw),
+        ):
             self.ticker.tick()
 
         self.mock_draw.text.assert_called_once()

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -43,7 +43,9 @@ class TestSdNotify(unittest.TestCase):
             self.assertEqual(data, b"WATCHDOG=1")
 
     def test_silently_ignores_missing_socket_env(self):
-        env_without_socket = {k: v for k, v in os.environ.items() if k != "NOTIFY_SOCKET"}
+        env_without_socket = {
+            k: v for k, v in os.environ.items() if k != "NOTIFY_SOCKET"
+        }
         with patch.dict(os.environ, env_without_socket, clear=True):
             sd_notify("READY=1")  # must not raise
 


### PR DESCRIPTION
## Summary
- Adds `.pre-commit-config.yaml` with `ruff` (linter, `--fix`) and `ruff-format` hooks at rev `v0.11.2`
- Adds `[tool.ruff]` and `[tool.ruff.lint]` config to `pyproject.toml` (target py313, rules: E, F, I, UP, W, B, C4, SIM; excludes vendored `lib/`)
- Adds `pre-commit>=4.0.0` and `ruff>=0.11.2` to `dev` optional-dependencies
- Applies initial ruff auto-fixes and reformatting to existing codebase

## Test plan
- [x] `pip install -e ".[dev]"` installs cleanly
- [x] `pre-commit install` writes `.git/hooks/pre-commit`
- [x] `pre-commit run --all-files` passes with no errors
- [x] `git commit` triggers hooks automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)