### PR TITLE
Add SonarCloud static analysis workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,35 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for blame and new-code detection
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]" pytest-cov
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src/epaper --cov-report=xml
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,7 +29,7 @@ jobs:
           pytest --cov=src/epaper --cov-report=xml
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v3
+        uses: SonarSource/sonarcloud-github-action@eb211723266fe8e83102bac7361f0a05c3ac1d1b  # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # E-Paper Bitcoin Price Ticker
 
-![Python](https://img.shields.io/badge/python-3.13%2B-blue)
-![Platform](https://img.shields.io/badge/platform-Raspberry%20Pi%20%7C%20Linux-lightgrey.svg)
 ![License](https://img.shields.io/badge/license-MIT-green)
+![Platform](https://img.shields.io/badge/platform-Raspberry%20Pi%20%7C%20Linux-lightgrey.svg)
+![Python](https://img.shields.io/badge/python-3.13%2B-blue)
+|
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=alert_status)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=bugs)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=code_smells)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=coverage)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=security_rating)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
 
 Displays the current Bitcoin/USD price on a Waveshare 2.13" e-ink display (epd2in13 V2) connected to a Raspberry Pi. On startup it shows a Bitcoin logo, then enters a loop that refreshes the price every 5 minutes. The background alternates randomly between black and white on each refresh.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=janrothen_e-paper
+sonar.organization=janrothen
+
+sonar.sources=src
+sonar.tests=tests
+sonar.python.version=3.13
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.exclusions=src/epaper/lib/**


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sonarcloud.yml` — runs on push to `main` and on PRs; installs deps, generates coverage XML via `pytest-cov`, then triggers SonarCloud scan
- Adds `sonar-project.properties` — configures project key, org, source/test paths, Python version, coverage report path, and excludes vendored `lib/`

## Test plan
- [x] Add `SONAR_TOKEN` secret to repo settings
- [x] Merge PR and verify the SonarCloud workflow passes in Actions
- [x] Confirm Quality Gate is computed in SonarCloud dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)