### PR TITLE
Fix SonarCloud coverage reporting

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,11 +22,10 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]" pytest-cov
+        run: pip install -e ".[dev]"
 
       - name: Run tests with coverage
-        run: |
-          pytest --cov=src/epaper --cov-report=xml
+        run: pytest
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@eb211723266fe8e83102bac7361f0a05c3ac1d1b  # v3.0.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platform](https://img.shields.io/badge/platform-Raspberry%20Pi%20%7C%20Linux-lightgrey.svg)
 ![Python](https://img.shields.io/badge/python-3.13%2B-blue)
-|
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=alert_status)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=bugs)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=code_smells)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ![Python](https://img.shields.io/badge/python-3.13%2B-blue)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=alert_status)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=bugs)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=code_smells)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=coverage)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=janrothen_e-paper&metric=security_rating)](https://sonarcloud.io/project/overview?id=janrothen_e-paper)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ rpi = [
 ]
 dev = [
     "pytest>=8.0.0",
+    "pytest-cov>=5.0.0",
     "pre-commit>=4.0.0",
     "ruff>=0.11.2",
 ]
@@ -37,6 +38,7 @@ packages = ["src/epaper"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--cov=src/epaper --cov-report=xml"
 
 [tool.ruff]
 target-version = "py313"


### PR DESCRIPTION
## Summary
- Add `pytest-cov` to dev dependencies in `pyproject.toml`
- Move coverage config (`--cov=src/epaper --cov-report=xml`) into `[tool.pytest.ini_options]` so it runs consistently locally and in CI
- Simplify workflow — `pytest` alone now generates `coverage.xml`

## Test plan
- [ ] Merge and verify SonarCloud shows coverage > 0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)