### PR TITLE
Fix coverage paths for SonarCloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ packages = ["src/epaper"]
 testpaths = ["tests"]
 addopts = "--cov=src/epaper --cov-report=xml"
 
+[tool.coverage.run]
+source = ["src/epaper"]
+
+[tool.coverage.report]
+relative_files = true
+
 [tool.ruff]
 target-version = "py313"
 line-length = 88


### PR DESCRIPTION
## Summary
- Set `relative_files = true` in `[tool.coverage.report]` so `coverage.xml` uses relative paths instead of absolute runner paths that SonarCloud cannot resolve

## Test plan
- [ ] Merge and verify SonarCloud shows coverage > 0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)