### PR TITLE
Fix epdconfig platform detection on Linux 6.6+ (Debian Trixie)

### DIFF
--- a/src/epaper/display.py
+++ b/src/epaper/display.py
@@ -14,7 +14,23 @@ if _LIB_DIR.exists():
 try:
     from waveshare_epd import epd2in13_V2
 except ModuleNotFoundError:
-    from epaper.lib import epd2in13_V2
+    import os as _os
+
+    _real_exists = _os.path.exists
+
+    def _patched_exists(path: str) -> bool:
+        # On Linux 6.6+ (Debian Trixie) the BCM gpiomem driver was renamed
+        # from gpiomem-bcm2835 to rpi-gpiomem, breaking epdconfig.py's
+        # platform detection which would otherwise fall through to JetsonNano.
+        if path == "/sys/bus/platform/drivers/gpiomem-bcm2835":
+            return _real_exists("/sys/bus/platform/drivers/rpi-gpiomem")
+        return _real_exists(path)
+
+    _os.path.exists = _patched_exists
+    try:
+        from epaper.lib import epd2in13_V2
+    finally:
+        _os.path.exists = _real_exists
 
 
 class Display:


### PR DESCRIPTION
## Summary

- On Debian Trixie (Linux 6.6+) the BCM gpiomem driver was renamed from `gpiomem-bcm2835` to `rpi-gpiomem`
- `epdconfig.py`'s path-based platform check falls through to `JetsonNano()`, which then fails to import `Jetson.GPIO` and crashes
- Patches `os.path.exists` in `display.py` before the lib fallback import to redirect the old path to the new one — no changes to vendored `lib/` code

## Test plan

- [x] Deploy to Raspberry Pi 4 running Debian Trixie with `pip install -e ".[rpi]"` removed from venv (lib fallback active)
- [x] Confirm `systemctl start btcticker` succeeds and display updates
- [x] Confirm the patch has no effect when `waveshare-epd` pip package is installed (fast path used instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)