### PR TITLE
Extract price protocols to dedicated module

### DIFF
--- a/src/btcticker/price/protocols.py
+++ b/src/btcticker/price/protocols.py
@@ -1,0 +1,9 @@
+from typing import Protocol
+
+
+class PriceSource(Protocol):
+    def retrieve_data(self) -> dict | None: ...
+
+
+class PriceFormatter(Protocol):
+    def formatted_price_from_data(self, data: dict | None) -> str: ...

--- a/src/btcticker/price_ticker.py
+++ b/src/btcticker/price_ticker.py
@@ -2,20 +2,11 @@ import logging
 import random
 import time
 from pathlib import Path
-from typing import Protocol
 
 from PIL import Image, ImageDraw, ImageFont
 
 from btcticker.display import Display
-
-
-class PriceClient(Protocol):
-    def retrieve_data(self) -> dict | None: ...
-
-
-class PriceExtractor(Protocol):
-    def formatted_price_from_data(self, data: dict | None) -> str: ...
-
+from btcticker.price.protocols import PriceFormatter, PriceSource
 
 _MEDIA_DIR = Path(__file__).parent / "media"
 
@@ -38,8 +29,8 @@ class PriceTicker:
     def __init__(
         self,
         display: Display,
-        price_client: PriceClient,
-        price_extractor: PriceExtractor,
+        price_client: PriceSource,
+        price_extractor: PriceFormatter,
         refresh_interval: int = DEFAULT_REFRESH_INTERVAL,
     ) -> None:
         self.display = display


### PR DESCRIPTION
## Summary
- Move `PriceClient` and `PriceExtractor` `Protocol` definitions out of `price_ticker.py` into a new `price/protocols.py` module, renamed to `PriceSource` and `PriceFormatter`.
- Resolves a name collision where the `PriceExtractor` protocol shadowed the concrete `PriceExtractor` class in `price/price_extractor.py`, making consumer-side type hints ambiguous.
- Also renames `PriceClient` → `PriceSource` for a clearer intent (describes a role, not a class).

## Why
Two classes named `PriceExtractor` in the same package — one a `Protocol`, one the concrete implementation — is a readability trap. Structural typing makes it "work," but any reader has to disambiguate by module. Protocols now live alongside the concrete implementations they describe.

## Test plan
- [x] `pytest` — 65/65 passing
- [x] Pre-commit hooks (ruff, ruff-format) pass