### PR TITLE
Remove constructor side-effects; fix stop() log

### DIFF
--- a/src/btcticker/__main__.py
+++ b/src/btcticker/__main__.py
@@ -27,6 +27,7 @@ def main() -> None:
     refresh_interval = cfg.get("refresh_interval", 300)
 
     display = Display()
+    display.open()
     price_client = BitcoinPriceClient()
     price_extractor = PriceExtractor(currency, symbol)
     ticker = PriceTicker(display, price_client, price_extractor, refresh_interval)

--- a/src/btcticker/display.py
+++ b/src/btcticker/display.py
@@ -45,6 +45,9 @@ class Display:
         self._epd = epd2in13_V2.EPD()
         self.width = self._epd.height  # 250 pixels
         self.height = self._epd.width  # 122 pixels
+
+    def open(self) -> None:
+        """Initialize the hardware and clear the screen to a known state."""
         self.init()
         self.clear()
 

--- a/src/btcticker/price_ticker.py
+++ b/src/btcticker/price_ticker.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import time
+from functools import cached_property
 from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFont
@@ -39,7 +40,10 @@ class PriceTicker:
         self._refresh_interval = refresh_interval
         self._stopped = False
         self._last_refresh = float("-inf")  # guarantees refresh on first tick()
-        self._font = ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
+
+    @cached_property
+    def _font(self) -> ImageFont.FreeTypeFont:
+        return ImageFont.truetype(str(FONT_FILE), FONT_SIZE)
 
     def start(self) -> None:
         """Display the intro image and pause before the price loop begins."""
@@ -76,10 +80,10 @@ class PriceTicker:
             time.sleep(1)
 
     def stop(self) -> None:
-        logging.info("shutting down")
         if self._stopped:
             return
         self._stopped = True
+        logging.info("shutting down")
         try:
             self.display.init()
             self.display.clear()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -33,13 +33,20 @@ class TestDisplay(unittest.TestCase):
         self.assertEqual(self.display.width, 250)
         self.assertEqual(self.display.height, 122)
 
+    def test_constructor_does_not_touch_hardware(self):
+        self.mock_epd.init.assert_not_called()
+        self.mock_epd.Clear.assert_not_called()
+
+    def test_open_initializes_and_clears(self):
+        self.display.open()
+        self.mock_epd.init.assert_called_once_with("FULL_UPDATE")
+        self.mock_epd.Clear.assert_called_once_with(0xFF)
+
     def test_init_calls_epd_init(self):
-        self.mock_epd.init.reset_mock()
         self.display.init()
         self.mock_epd.init.assert_called_once_with("FULL_UPDATE")
 
     def test_clear_calls_epd_clear(self):
-        self.mock_epd.Clear.reset_mock()
         self.display.clear()
         self.mock_epd.Clear.assert_called_once_with(0xFF)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,10 +15,17 @@ sys.modules.pop("btcticker.display", None)
 sys.modules.pop("btcticker.__main__", None)
 
 
-def _run_main(mock_ticker, mock_shutdown, mock_sd_notify, extra_config=None):
+def _run_main(
+    mock_ticker,
+    mock_shutdown,
+    mock_sd_notify,
+    extra_config=None,
+    mock_display_cls=None,
+):
     cfg = extra_config or {}
+    display_cls = mock_display_cls or MagicMock()
     with (
-        patch("btcticker.__main__.Display"),
+        patch("btcticker.__main__.Display", display_cls),
         patch("btcticker.__main__.BitcoinPriceClient"),
         patch("btcticker.__main__.PriceExtractor"),
         patch("btcticker.__main__.PriceTicker", return_value=mock_ticker),
@@ -44,6 +51,18 @@ class TestMain(unittest.TestCase):
     def test_ticker_start_is_called(self):
         self._run([True])
         self.mock_ticker.start.assert_called_once()
+
+    def test_display_opened_before_ticker_start(self):
+        mock_display_cls = MagicMock()
+        mock_display = mock_display_cls.return_value
+        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        _run_main(
+            self.mock_ticker,
+            self.mock_shutdown,
+            self.mock_sd_notify,
+            mock_display_cls=mock_display_cls,
+        )
+        mock_display.open.assert_called_once()
 
     def test_sd_notify_ready(self):
         self._run([True])

--- a/tests/test_price_ticker.py
+++ b/tests/test_price_ticker.py
@@ -8,14 +8,13 @@ def _make_ticker():
     mock_display.width = 250
     mock_display.height = 122
 
-    with patch("btcticker.price_ticker.ImageFont.truetype", return_value=MagicMock()):
-        from btcticker.price_ticker import PriceTicker
+    from btcticker.price_ticker import PriceTicker
 
-        ticker = PriceTicker(
-            display=mock_display,
-            price_client=MagicMock(),
-            price_extractor=MagicMock(),
-        )
+    ticker = PriceTicker(
+        display=mock_display,
+        price_client=MagicMock(),
+        price_extractor=MagicMock(),
+    )
 
     return ticker, mock_display
 
@@ -67,6 +66,15 @@ class TestPriceTickerStop(unittest.TestCase):
         self.assertFalse(self.ticker._stopped)
         self.ticker.stop()
         self.assertTrue(self.ticker._stopped)
+
+    def test_stop_logs_shutdown_only_once(self):
+        import logging as _logging
+
+        with self.assertLogs("root", level=_logging.INFO) as cm:
+            self.ticker.stop()
+            self.ticker.stop()  # second call must not log again
+        shutdown_logs = [m for m in cm.output if "shutting down" in m]
+        self.assertEqual(len(shutdown_logs), 1)
 
     def test_stop_swallows_display_errors(self):
         self.mock_display.init.side_effect = OSError("SPI error")


### PR DESCRIPTION
## Summary
- `Display.__init__` no longer performs hardware I/O. The `init()` + `clear()` pair now lives in an explicit `open()` method, called by `__main__.py` after construction.
- `PriceTicker._font` becomes a `@cached_property`, so `ImageFont.truetype` runs lazily on first `tick()` instead of at construction time.
- `PriceTicker.stop()` now logs "shutting down" below the idempotency guard, so repeated calls (e.g. signal handler + finally block) no longer duplicate the log line.

## Why
Constructors that open files or touch hardware are awkward to test and couple object creation with lifecycle. Moving these side-effects into explicit methods makes the classes constructible in isolation and clarifies the setup/teardown boundary. The `stop()` log fix is a small correctness nit spotted during the same review pass.

## Test plan
- [x] `pytest` — 69/69 passing (added tests: constructor-is-pure for `Display`, `open()` behavior, `display.open()` called in `main`, idempotent shutdown log)
- [x] Pre-commit hooks (ruff, ruff-format) pass