### PR TITLE
Inject endpoint into BitcoinPriceClient

### DIFF
--- a/src/btcticker/__main__.py
+++ b/src/btcticker/__main__.py
@@ -25,10 +25,11 @@ def main() -> None:
     currency = cfg.get("currency", "USD")
     symbol = cfg.get("symbol", "$")
     refresh_interval = cfg.get("refresh_interval", 300)
+    endpoint = cfg["service_endpoint"]
 
     display = Display()
     display.open()
-    price_client = BitcoinPriceClient()
+    price_client = BitcoinPriceClient(endpoint)
     price_extractor = PriceExtractor(currency, symbol)
     ticker = PriceTicker(display, price_client, price_extractor, refresh_interval)
     shutdown = GracefulShutdown()

--- a/src/btcticker/price/bitcoin_price_client.py
+++ b/src/btcticker/price/bitcoin_price_client.py
@@ -4,7 +4,6 @@ import time
 
 import requests
 
-from btcticker.config import config
 from btcticker.http_client import HttpClient, HttpError
 
 MAX_RETRIES = 3
@@ -18,9 +17,9 @@ class BitcoinPriceClient:
     e.g. {"USD": {"last": 84500.0, ...}, "CHF": {"last": 75000.0, ...}}.
     """
 
-    def __init__(self, http_client: HttpClient | None = None) -> None:
+    def __init__(self, endpoint: str, http_client: HttpClient | None = None) -> None:
+        self._endpoint = endpoint
         self._http = http_client or HttpClient()
-        self._endpoint = config()["bitcoin"]["price"]["service_endpoint"]
 
     def retrieve_data(self) -> dict | None:
         """Fetch price data, retrying up to MAX_RETRIES times on failure.

--- a/tests/test_bitcoin_price_client.py
+++ b/tests/test_bitcoin_price_client.py
@@ -17,13 +17,16 @@ from btcticker.price.price_extractor import PriceExtractor
 FIXTURE = Path(__file__).parent / "mock_data.json"
 
 
+TEST_ENDPOINT = "https://example.test/ticker"
+
+
 def _make_client(side_effect=None, return_value=None):
     mock_http = MagicMock()
     if side_effect is not None:
         mock_http.get.side_effect = side_effect
     elif return_value is not None:
         mock_http.get.return_value = return_value
-    return BitcoinPriceClient(http_client=mock_http), mock_http
+    return BitcoinPriceClient(TEST_ENDPOINT, http_client=mock_http), mock_http
 
 
 class TestPriceExtractorIntegration(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,18 +15,25 @@ sys.modules.pop("btcticker.display", None)
 sys.modules.pop("btcticker.__main__", None)
 
 
+_DEFAULT_CONFIG = {
+    "bitcoin": {"price": {"service_endpoint": "https://example.test/ticker"}}
+}
+
+
 def _run_main(
     mock_ticker,
     mock_shutdown,
     mock_sd_notify,
     extra_config=None,
     mock_display_cls=None,
+    mock_price_client_cls=None,
 ):
-    cfg = extra_config or {}
+    cfg = extra_config if extra_config is not None else _DEFAULT_CONFIG
     display_cls = mock_display_cls or MagicMock()
+    price_client_cls = mock_price_client_cls or MagicMock()
     with (
         patch("btcticker.__main__.Display", display_cls),
-        patch("btcticker.__main__.BitcoinPriceClient"),
+        patch("btcticker.__main__.BitcoinPriceClient", price_client_cls),
         patch("btcticker.__main__.PriceExtractor"),
         patch("btcticker.__main__.PriceTicker", return_value=mock_ticker),
         patch("btcticker.__main__.GracefulShutdown", return_value=mock_shutdown),
@@ -98,7 +105,15 @@ class TestMain(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 1)
 
     def test_config_currency_and_symbol_passed_to_price_extractor(self):
-        cfg = {"bitcoin": {"price": {"currency": "CHF", "symbol": "CHF "}}}
+        cfg = {
+            "bitcoin": {
+                "price": {
+                    "currency": "CHF",
+                    "symbol": "CHF ",
+                    "service_endpoint": "https://example.test/ticker",
+                }
+            }
+        }
         mock_extractor_cls = MagicMock()
         type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
         with (
@@ -116,6 +131,19 @@ class TestMain(unittest.TestCase):
 
             main()
         mock_extractor_cls.assert_called_once_with("CHF", "CHF ")
+
+    def test_service_endpoint_passed_to_price_client(self):
+        cfg = {"bitcoin": {"price": {"service_endpoint": "https://my.ticker/api"}}}
+        mock_client_cls = MagicMock()
+        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        _run_main(
+            self.mock_ticker,
+            self.mock_shutdown,
+            self.mock_sd_notify,
+            extra_config=cfg,
+            mock_price_client_cls=mock_client_cls,
+        )
+        mock_client_cls.assert_called_once_with("https://my.ticker/api")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `BitcoinPriceClient.__init__` now takes `endpoint: str` as a required argument.
- Removes the `from btcticker.config import config` import from the client.
- `__main__.py` reads `service_endpoint` from config and passes it to the client.

## Why
Pulling the endpoint from the global `config()` inside the client's constructor coupled the client to a module-level cached singleton. That made per-test endpoint overrides clumsy (tests had to monkeypatch the global config) and obscured the client's actual dependencies. Keeping config access confined to `__main__` (the composition root) is a standard DI pattern and makes the client trivially testable.

## Test plan
- [x] `pytest` — 70/70 passing (added `test_service_endpoint_passed_to_price_client`)
- [x] Pre-commit hooks (ruff, ruff-format) pass