### PR TITLE
Scope display.py driver import behind a private function

### DIFF
--- a/src/btcticker/display.py
+++ b/src/btcticker/display.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -6,31 +7,49 @@ from PIL import Image
 _PKG_DIR = Path(__file__).parent
 _LIB_DIR = _PKG_DIR / "lib"
 
-# The vendored epd2in13_V2.py imports epdconfig as a bare sibling (not via the
-# package), so the lib directory must be on sys.path for that import to resolve.
-if _LIB_DIR.exists():
-    sys.path.insert(0, str(_LIB_DIR))
 
-try:
-    from waveshare_epd import epd2in13_V2
-except ModuleNotFoundError:
-    import os as _os
+def _load_epd_driver():
+    """Import the Waveshare epd2in13_V2 driver.
 
-    _real_exists = _os.path.exists
+    Prefers the `waveshare_epd` pip package when available. Falls back to
+    the vendored copy under `lib/`, which requires two workarounds:
 
-    def _patched_exists(path: str) -> bool:
-        # On Linux 6.6+ (Debian Trixie) the BCM gpiomem driver was renamed
-        # from gpiomem-bcm2835 to rpi-gpiomem, breaking epdconfig.py's
-        # platform detection which would otherwise fall through to JetsonNano.
+    1. The vendored `epd2in13_V2.py` imports `epdconfig` as a bare sibling,
+       so `lib/` must be on sys.path for that import to resolve.
+    2. On Linux 6.6+ (Debian Trixie) the BCM gpiomem driver was renamed
+       from `gpiomem-bcm2835` to `rpi-gpiomem`. The vendored `epdconfig.py`
+       uses the old name for platform detection and would otherwise fall
+       through to a JetsonNano code path. We patch `os.path.exists` for
+       the duration of the fallback import to redirect the stale lookup,
+       and restore it immediately afterwards.
+    """
+    if _LIB_DIR.exists():
+        sys.path.insert(0, str(_LIB_DIR))
+
+    try:
+        from waveshare_epd import epd2in13_V2
+
+        return epd2in13_V2
+    except ModuleNotFoundError:
+        pass
+
+    real_exists = os.path.exists
+
+    def patched_exists(path: str) -> bool:
         if path == "/sys/bus/platform/drivers/gpiomem-bcm2835":
-            return _real_exists("/sys/bus/platform/drivers/rpi-gpiomem")
-        return _real_exists(path)
+            return real_exists("/sys/bus/platform/drivers/rpi-gpiomem")
+        return real_exists(path)
 
-    _os.path.exists = _patched_exists
+    os.path.exists = patched_exists
     try:
         from btcticker.lib import epd2in13_V2
+
+        return epd2in13_V2
     finally:
-        _os.path.exists = _real_exists
+        os.path.exists = real_exists
+
+
+_epd_driver = _load_epd_driver()
 
 
 class Display:
@@ -42,7 +61,7 @@ class Display:
     """
 
     def __init__(self) -> None:
-        self._epd = epd2in13_V2.EPD()
+        self._epd = _epd_driver.EPD()
         self.width = self._epd.height  # 250 pixels
         self.height = self._epd.width  # 122 pixels
 


### PR DESCRIPTION
## Summary
- Wrap the Waveshare driver import (pip package first, vendored fallback with `os.path.exists` monkeypatch) in a new `_load_epd_driver()` helper.
- The monkeypatch's `real_exists`/`patched_exists` are now function-locals instead of module-level bindings.
- Consolidates the two workarounds (sys.path prepend, gpiomem-bcm2835 → rpi-gpiomem redirect) under a single docstring.

## Why
The original top-level flow was ~20 lines of procedural import logic interleaved with a try/finally monkeypatch. A named function with a clear docstring communicates intent better and keeps the module namespace clean — no `_real_exists` or `_patched_exists` lingering as module attributes.

Pure refactor, no behavior change. Display still references the driver module loaded at import-time.

## Test plan
- [x] `pytest` — 79/79 passing
- [x] Pre-commit hooks (ruff, ruff-format) pass