### PR TITLE
Simplify format_price; inline price_without_cents

### DIFF
--- a/src/btcticker/price/price_extractor.py
+++ b/src/btcticker/price/price_extractor.py
@@ -2,6 +2,9 @@ import math
 
 type PriceData = dict | None
 
+_MILLION = 1_000_000
+_THOUSAND = 1_000
+
 
 class PriceExtractor:
     def __init__(self, currency: str, symbol: str) -> None:
@@ -30,23 +33,16 @@ class PriceExtractor:
         Trailing zeros are stripped. Values are truncated, never rounded,
         so the display never shows a price higher than the actual value.
         """
-        p = self.price_without_cents(price)
-        if p >= 100_000:
-            value = p / 1_000_000
-            truncated = (
-                int(value * 1000) / 1000
-            )  # truncate to 3 decimal places, no rounding
-            formatted = f"{truncated:.3f}".rstrip("0").rstrip(".")
-            return f"{self.symbol}{formatted}M"
-        elif p >= 1_000:
-            value = p / 1_000
-            truncated = (
-                int(value * 100) / 100
-            )  # truncate to 2 decimal places, no rounding
-            formatted = f"{truncated:.2f}".rstrip("0").rstrip(".")
-            return f"{self.symbol}{formatted}k"
-        else:
-            return f"{self.symbol}{p}"
+        whole = math.floor(price)
+        if whole >= 100_000:
+            return f"{self.symbol}{self._compact(whole / _MILLION, decimals=3)}M"
+        if whole >= 1_000:
+            return f"{self.symbol}{self._compact(whole / _THOUSAND, decimals=2)}k"
+        return f"{self.symbol}{whole}"
 
-    def price_without_cents(self, price: float) -> int:
-        return math.floor(price)
+    @staticmethod
+    def _compact(value: float, decimals: int) -> str:
+        """Truncate to `decimals` places (never round) and strip trailing zeros."""
+        scale = 10**decimals
+        truncated = int(value * scale) / scale
+        return f"{truncated:.{decimals}f}".rstrip("0").rstrip(".")


### PR DESCRIPTION
## Summary
- Extract the `truncate → rstrip → format` logic shared by the millions and thousands branches into a single `_compact(value, decimals)` static helper.
- Inline `price_without_cents` (a one-line `math.floor` wrapper) back into `format_price`.

## Why
The two format branches were near-duplicates differing only in magnitude and decimal count, so the truncation math was written twice. Consolidating into `_compact` makes the threshold table (millions / thousands / raw) the only thing you read top-to-bottom — the formatting detail moves under the helper.

`price_without_cents` was a one-liner method whose name was longer than its body, wrapping a single `math.floor` call. Inlining removes an indirection for zero benefit.

Pure refactor — no behavior change, same test assertions pass unchanged.

## Test plan
- [x] `pytest` — 79/79 passing (no test changes required; behavior identical)
- [x] Pre-commit hooks (ruff, ruff-format) pass