### PR TITLE
Polish HTTP layer: get_json, drop \n, inject retries

### DIFF
--- a/src/btcticker/http_client.py
+++ b/src/btcticker/http_client.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 
 DEFAULT_TIMEOUT = 10  # seconds
@@ -5,7 +7,7 @@ DEFAULT_TIMEOUT = 10  # seconds
 
 class HttpError(Exception):
     def __init__(self, status_code: int, body: str) -> None:
-        super().__init__(f"\nCode: {status_code}\nResult: {body}")
+        super().__init__(f"HTTP {status_code}: {body}")
         self.status_code = status_code
         self.body = body
 
@@ -19,6 +21,14 @@ class HttpClient:
 
     def get(self, url: str) -> str:
         return self._check(requests.get(url, timeout=self.timeout))
+
+    def get_json(self, url: str) -> object:
+        """Fetch `url` and parse the response body as JSON.
+
+        Raises HttpError on non-2xx responses, json.JSONDecodeError on
+        malformed or empty bodies.
+        """
+        return json.loads(self.get(url))
 
     def post(self, url: str, json_data: object | None = None) -> str:
         return self._check(requests.post(url, json=json_data, timeout=self.timeout))

--- a/src/btcticker/price/bitcoin_price_client.py
+++ b/src/btcticker/price/bitcoin_price_client.py
@@ -17,34 +17,38 @@ class BitcoinPriceClient:
     e.g. {"USD": {"last": 84500.0, ...}, "CHF": {"last": 75000.0, ...}}.
     """
 
-    def __init__(self, endpoint: str, http_client: HttpClient | None = None) -> None:
+    def __init__(
+        self,
+        endpoint: str,
+        http_client: HttpClient | None = None,
+        max_retries: int = MAX_RETRIES,
+        retry_delay: int = RETRY_DELAY,
+    ) -> None:
         self._endpoint = endpoint
         self._http = http_client or HttpClient()
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
 
     def retrieve_data(self) -> dict | None:
-        """Fetch price data, retrying up to MAX_RETRIES times on failure.
+        """Fetch price data, retrying up to max_retries times on failure.
 
         Returns the parsed JSON dict on success, or None if all attempts fail.
         """
-        for attempt in range(1, MAX_RETRIES + 1):
+        for attempt in range(1, self._max_retries + 1):
             try:
-                result = self._http.get(self._endpoint)
-                if result:
-                    return json.loads(result)
-                logging.warning(
-                    "Price fetch attempt %d/%d returned empty response",
-                    attempt,
-                    MAX_RETRIES,
-                )
+                return self._http.get_json(self._endpoint)
             except (
                 HttpError,
                 requests.RequestException,
                 json.JSONDecodeError,
             ) as e:
                 logging.warning(
-                    "Price fetch attempt %d/%d failed: %s", attempt, MAX_RETRIES, e
+                    "Price fetch attempt %d/%d failed: %s",
+                    attempt,
+                    self._max_retries,
+                    e,
                 )
-            if attempt < MAX_RETRIES:
-                time.sleep(RETRY_DELAY)
-        logging.error("All %d price fetch attempts failed", MAX_RETRIES)
+            if attempt < self._max_retries:
+                time.sleep(self._retry_delay)
+        logging.error("All %d price fetch attempts failed", self._max_retries)
         return None

--- a/tests/test_bitcoin_price_client.py
+++ b/tests/test_bitcoin_price_client.py
@@ -15,18 +15,17 @@ from btcticker.price.mock import BitcoinPriceClientMock
 from btcticker.price.price_extractor import PriceExtractor
 
 FIXTURE = Path(__file__).parent / "mock_data.json"
-
-
 TEST_ENDPOINT = "https://example.test/ticker"
 
 
-def _make_client(side_effect=None, return_value=None):
+def _make_client(side_effect=None, return_value=None, **kwargs):
     mock_http = MagicMock()
     if side_effect is not None:
-        mock_http.get.side_effect = side_effect
+        mock_http.get_json.side_effect = side_effect
     elif return_value is not None:
-        mock_http.get.return_value = return_value
-    return BitcoinPriceClient(TEST_ENDPOINT, http_client=mock_http), mock_http
+        mock_http.get_json.return_value = return_value
+    client = BitcoinPriceClient(TEST_ENDPOINT, http_client=mock_http, **kwargs)
+    return client, mock_http
 
 
 class TestPriceExtractorIntegration(unittest.TestCase):
@@ -69,39 +68,29 @@ class TestBitcoinPriceClientErrorHandling(unittest.TestCase):
         )
 
     def test_malformed_json_returns_none(self):
-        client, _ = _make_client(return_value="not valid json {")
-        with patch("btcticker.price.bitcoin_price_client.time.sleep"):
-            self.assertIsNone(client.retrieve_data())
-
-    def test_empty_response_returns_none(self):
-        client, _ = _make_client(return_value="")
-        with patch("btcticker.price.bitcoin_price_client.time.sleep"):
-            self.assertIsNone(client.retrieve_data())
+        self.assertIsNone(
+            self._run_with_error(json.JSONDecodeError("bad", "not valid {", 0))
+        )
 
 
 class TestBitcoinPriceClientRetry(unittest.TestCase):
     def test_succeeds_on_first_attempt_without_retrying(self):
-        good_response = json.dumps({"USD": {"last": 50000}})
-        client, mock_http = _make_client(return_value=good_response)
+        client, _ = _make_client(return_value={"USD": {"last": 50000}})
         with patch("btcticker.price.bitcoin_price_client.time.sleep") as mock_sleep:
             result = client.retrieve_data()
 
-        self.assertIsNotNone(result)
+        self.assertEqual(result, {"USD": {"last": 50000}})
         mock_sleep.assert_not_called()
 
     def test_retries_on_failure_and_returns_data_on_success(self):
-        good_response = json.dumps({"USD": {"last": 50000}})
-        client, mock_http = _make_client(
-            side_effect=[
-                HttpError(503, "fail"),
-                HttpError(503, "fail"),
-                good_response,
-            ]
+        good = {"USD": {"last": 50000}}
+        client, _ = _make_client(
+            side_effect=[HttpError(503, "fail"), HttpError(503, "fail"), good]
         )
         with patch("btcticker.price.bitcoin_price_client.time.sleep") as mock_sleep:
             result = client.retrieve_data()
 
-        self.assertIsNotNone(result)
+        self.assertEqual(result, good)
         self.assertEqual(mock_sleep.call_count, 2)
         mock_sleep.assert_called_with(RETRY_DELAY)
 
@@ -111,7 +100,7 @@ class TestBitcoinPriceClientRetry(unittest.TestCase):
             result = client.retrieve_data()
 
         self.assertIsNone(result)
-        self.assertEqual(mock_http.get.call_count, MAX_RETRIES)
+        self.assertEqual(mock_http.get_json.call_count, MAX_RETRIES)
         self.assertEqual(mock_sleep.call_count, MAX_RETRIES - 1)
 
     def test_no_sleep_after_last_failed_attempt(self):
@@ -120,6 +109,23 @@ class TestBitcoinPriceClientRetry(unittest.TestCase):
             client.retrieve_data()
 
         self.assertEqual(mock_sleep.call_count, MAX_RETRIES - 1)
+
+    def test_injected_max_retries_overrides_default(self):
+        client, mock_http = _make_client(
+            side_effect=HttpError(503, "fail"), max_retries=5
+        )
+        with patch("btcticker.price.bitcoin_price_client.time.sleep"):
+            client.retrieve_data()
+        self.assertEqual(mock_http.get_json.call_count, 5)
+
+    def test_injected_retry_delay_overrides_default(self):
+        client, _ = _make_client(
+            side_effect=[HttpError(503, "fail"), {"USD": {"last": 1}}],
+            retry_delay=42,
+        )
+        with patch("btcticker.price.bitcoin_price_client.time.sleep") as mock_sleep:
+            client.retrieve_data()
+        mock_sleep.assert_called_once_with(42)
 
 
 if __name__ == "__main__":

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -50,6 +51,57 @@ class TestHttpClientStatusCodes(unittest.TestCase):
             HttpClient().get("http://example.com")
         self.assertEqual(ctx.exception.status_code, 503)
         self.assertEqual(ctx.exception.body, "unavailable")
+
+    def test_http_error_message_does_not_start_with_newline(self):
+        error = HttpError(500, "boom")
+        self.assertFalse(str(error).startswith("\n"))
+        self.assertIn("500", str(error))
+        self.assertIn("boom", str(error))
+
+
+class TestHttpClientGetJson(unittest.TestCase):
+    def _mock_response(self, status_code=200, text="{}"):
+        mock = MagicMock()
+        mock.status_code = status_code
+        mock.text = text
+        return mock
+
+    def test_parses_valid_json_body(self):
+        with patch(
+            "btcticker.http_client.requests.get",
+            return_value=self._mock_response(200, '{"a": 1}'),
+        ):
+            self.assertEqual(HttpClient().get_json("http://example.com"), {"a": 1})
+
+    def test_raises_json_decode_error_on_malformed_body(self):
+        with (
+            patch(
+                "btcticker.http_client.requests.get",
+                return_value=self._mock_response(200, "not json {"),
+            ),
+            self.assertRaises(json.JSONDecodeError),
+        ):
+            HttpClient().get_json("http://example.com")
+
+    def test_raises_json_decode_error_on_empty_body(self):
+        with (
+            patch(
+                "btcticker.http_client.requests.get",
+                return_value=self._mock_response(200, ""),
+            ),
+            self.assertRaises(json.JSONDecodeError),
+        ):
+            HttpClient().get_json("http://example.com")
+
+    def test_raises_http_error_on_non_2xx(self):
+        with (
+            patch(
+                "btcticker.http_client.requests.get",
+                return_value=self._mock_response(500, "boom"),
+            ),
+            self.assertRaises(HttpError),
+        ):
+            HttpClient().get_json("http://example.com")
 
 
 class TestHttpClientTimeout(unittest.TestCase):


### PR DESCRIPTION
## Summary
- **`HttpClient.get_json(url)`** — new method that fetches + parses JSON. `BitcoinPriceClient` now calls it instead of `get()` + `json.loads()`.
- **`HttpError` message format** — drops the leading `\n`. New format: `HTTP 500: <body>` instead of `\nCode: 500\nResult: <body>`.
- **Injectable retry config** — `BitcoinPriceClient.__init__` accepts `max_retries` and `retry_delay`, defaulting to the module-level `MAX_RETRIES` / `RETRY_DELAY`.

## Why
Every caller of `get()` in this codebase parses JSON next, so pushing `json.loads` down into the client collapses the `get + json.loads + empty-check` triple back into one call. The empty-body case is still covered — `json.loads("")` raises `JSONDecodeError`, which the retry loop already catches.

`HttpError`'s leading `\n` was a formatting wart that showed up oddly in log lines. `HTTP <code>: <body>` reads cleanly.

Making retry timing injectable lets tests exercise edge cases (e.g. fewer attempts) without patching module globals.

## Test plan
- [x] `pytest` — 85/85 passing
  - +4 tests for `get_json` (valid/malformed/empty/non-2xx)
  - +1 `HttpError` message format test
  - +2 retry-injection tests on the client
  - -1 test removed (`test_empty_response_returns_none` — the branch it covered no longer exists; coverage moved to the HTTP layer)
- [x] Pre-commit hooks (ruff, ruff-format) pass