### PR TITLE
Polish lifecycle: should_stop property and idempotent start

### DIFF
--- a/src/btcticker/__main__.py
+++ b/src/btcticker/__main__.py
@@ -41,7 +41,7 @@ def main() -> None:
     try:
         ticker.start()
         sd_notify("READY=1")
-        while not shutdown.kill_now:
+        while not shutdown.should_stop:
             ticker.tick()
             sd_notify("WATCHDOG=1")
     except Exception as ex:

--- a/src/btcticker/price_ticker.py
+++ b/src/btcticker/price_ticker.py
@@ -30,11 +30,18 @@ class PriceTicker:
         self.price_client = price_client
         self.price_extractor = price_extractor
         self._refresh_interval = refresh_interval
+        self._started = False
         self._stopped = False
         self._last_refresh = float("-inf")  # guarantees refresh on first tick()
 
     def start(self) -> None:
-        """Display the intro image and pause before the price loop begins."""
+        """Display the intro image and pause before the price loop begins.
+
+        No-op on repeated calls.
+        """
+        if self._started:
+            return
+        self._started = True
         self.display.show(self.renderer.render_intro())
         time.sleep(INTRO_PAUSE_SECONDS)
 

--- a/src/btcticker/utils/graceful_shutdown.py
+++ b/src/btcticker/utils/graceful_shutdown.py
@@ -5,37 +5,30 @@ from types import FrameType
 
 
 class GracefulShutdown:
-    """
-    Handles graceful shutdown of the application by catching system signals.
+    """Cooperative shutdown via SIGINT/SIGTERM handlers.
 
-    This class registers signal handlers for SIGINT (Ctrl+C) and SIGTERM (kill command)
-    to allow the application to shut down cleanly. Instead of immediately terminating,
-    it sets a flag that can be checked in the main application loop to perform cleanup
-    operations before exiting.
+    Flips an internal flag when signaled. Consumers poll `should_stop` from
+    the main loop to exit cleanly:
 
-    The kill_now flag serves as a cooperative shutdown mechanism, allowing ongoing
-    operations to complete or be interrupted safely.
-
-    Usage:
-        shutdown_handler = GracefulShutdown()
-        while not shutdown_handler.kill_now:
-            # Main application loop
+        shutdown = GracefulShutdown()
+        while not shutdown.should_stop:
             do_work()
-        # Perform cleanup here
     """
-
-    kill_now: bool
 
     def __init__(self) -> None:
-        self.kill_now = False
+        self._should_stop = False
         signal.signal(signal.SIGINT, self._exit)
         signal.signal(signal.SIGTERM, self._exit)
 
+    @property
+    def should_stop(self) -> bool:
+        return self._should_stop
+
     def _exit(self, signum: int, frame: FrameType | None) -> None:
-        """Set the kill flag on SIGINT/SIGTERM.
+        """Mark should_stop on SIGINT/SIGTERM.
 
         Uses print rather than logging because the logging module is not fully
         reentrant and can deadlock when called from a signal handler.
         """
         print(f"Received signal {signum}, shutting down...")
-        self.kill_now = True
+        self._should_stop = True

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -12,9 +12,9 @@ def _make():
 
 
 class TestGracefulShutdownInit(unittest.TestCase):
-    def test_kill_now_is_false_on_init(self):
+    def test_should_stop_is_false_on_init(self):
         gs = _make()
-        self.assertFalse(gs.kill_now)
+        self.assertFalse(gs.should_stop)
 
     def test_registers_sigint_handler(self):
         with patch("signal.signal") as mock_signal:
@@ -30,15 +30,15 @@ class TestGracefulShutdownInit(unittest.TestCase):
 
 
 class TestGracefulShutdownExit(unittest.TestCase):
-    def test_sets_kill_now_true(self):
+    def test_sets_should_stop_true(self):
         gs = _make()
         gs._exit(signal.SIGTERM, None)
-        self.assertTrue(gs.kill_now)
+        self.assertTrue(gs.should_stop)
 
     def test_works_for_sigint(self):
         gs = _make()
         gs._exit(signal.SIGINT, None)
-        self.assertTrue(gs.kill_now)
+        self.assertTrue(gs.should_stop)
 
     def test_prints_received_signal_number(self):
         gs = _make()
@@ -46,6 +46,13 @@ class TestGracefulShutdownExit(unittest.TestCase):
             gs._exit(15, None)
         printed = mock_print.call_args[0][0]
         self.assertIn("15", printed)
+
+
+class TestGracefulShutdownReadOnly(unittest.TestCase):
+    def test_should_stop_cannot_be_set_externally(self):
+        gs = _make()
+        with self.assertRaises(AttributeError):
+            gs.should_stop = True
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,8 +54,10 @@ class TestMain(unittest.TestCase):
         self.mock_sd_notify = MagicMock()
         self.mock_shutdown = MagicMock()
 
-    def _run(self, kill_now_sequence, **kwargs):
-        type(self.mock_shutdown).kill_now = PropertyMock(side_effect=kill_now_sequence)
+    def _run(self, should_stop_sequence, **kwargs):
+        type(self.mock_shutdown).should_stop = PropertyMock(
+            side_effect=should_stop_sequence
+        )
         _run_main(self.mock_ticker, self.mock_shutdown, self.mock_sd_notify, **kwargs)
 
     def test_ticker_start_is_called(self):
@@ -65,7 +67,7 @@ class TestMain(unittest.TestCase):
     def test_display_opened_before_ticker_start(self):
         mock_display_cls = MagicMock()
         mock_display = mock_display_cls.return_value
-        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        type(self.mock_shutdown).should_stop = PropertyMock(return_value=True)
         _run_main(
             self.mock_ticker,
             self.mock_shutdown,
@@ -95,14 +97,14 @@ class TestMain(unittest.TestCase):
 
     def test_ticker_stop_called_on_exception(self):
         self.mock_ticker.start.side_effect = RuntimeError("boom")
-        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        type(self.mock_shutdown).should_stop = PropertyMock(return_value=True)
         with self.assertRaises(SystemExit):
             _run_main(self.mock_ticker, self.mock_shutdown, self.mock_sd_notify)
         self.mock_ticker.stop.assert_called_once()
 
     def test_sys_exit_1_on_exception(self):
         self.mock_ticker.start.side_effect = RuntimeError("boom")
-        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        type(self.mock_shutdown).should_stop = PropertyMock(return_value=True)
         with self.assertRaises(SystemExit) as ctx:
             _run_main(self.mock_ticker, self.mock_shutdown, self.mock_sd_notify)
         self.assertEqual(ctx.exception.code, 1)
@@ -118,7 +120,7 @@ class TestMain(unittest.TestCase):
             }
         }
         mock_extractor_cls = MagicMock()
-        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        type(self.mock_shutdown).should_stop = PropertyMock(return_value=True)
         with (
             patch("btcticker.__main__.Display"),
             patch("btcticker.__main__.FrameRenderer"),
@@ -142,7 +144,7 @@ class TestMain(unittest.TestCase):
         mock_display.width = 250
         mock_display.height = 122
         mock_renderer_cls = MagicMock()
-        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        type(self.mock_shutdown).should_stop = PropertyMock(return_value=True)
         _run_main(
             self.mock_ticker,
             self.mock_shutdown,
@@ -155,7 +157,7 @@ class TestMain(unittest.TestCase):
     def test_service_endpoint_passed_to_price_client(self):
         cfg = {"bitcoin": {"price": {"service_endpoint": "https://my.ticker/api"}}}
         mock_client_cls = MagicMock()
-        type(self.mock_shutdown).kill_now = PropertyMock(return_value=True)
+        type(self.mock_shutdown).should_stop = PropertyMock(return_value=True)
         _run_main(
             self.mock_ticker,
             self.mock_shutdown,

--- a/tests/test_price_ticker.py
+++ b/tests/test_price_ticker.py
@@ -50,6 +50,14 @@ class TestPriceTickerStart(unittest.TestCase):
 
         mock_sleep.assert_called_once_with(INTRO_PAUSE_SECONDS)
 
+    def test_start_is_idempotent(self):
+        with patch("btcticker.price_ticker.time.sleep"):
+            self.ticker.start()
+            self.ticker.start()
+
+        self.mock_renderer.render_intro.assert_called_once_with()
+        self.mock_display.show.assert_called_once()
+
 
 class TestPriceTickerStop(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
- Rename `GracefulShutdown.kill_now` to `should_stop` and back it with a read-only `@property`, so consumers can't accidentally toggle the flag from outside the class.
- Make `PriceTicker.start()` idempotent by guarding on a `_started` flag; a repeated call is now a no-op instead of re-rendering the intro and sleeping again.
- Update callers (`__main__.py`) and tests to the new naming, and add coverage for both behaviours.

## Test plan
- [x] `pytest` — 87 passed
- [x] `ruff` pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)